### PR TITLE
tst_res.c: undefined symbol TEST_ERRNO

### DIFF
--- a/lib/tst_res.c
+++ b/lib/tst_res.c
@@ -495,9 +495,8 @@ static void tst_print(char *tcid, int tnum, int ttype, char *tmesg)
 
 	if (ttype & TTERRNO) {
 		size += snprintf(message + size, sizeof(message) - size,
-				 ": TEST_ERRNO=%s(%i): %s",
-				 strerrnodef(TEST_ERRNO), (int)TEST_ERRNO,
-				 strerror(TEST_ERRNO));
+				 ": errno=%s(%i): %s",
+				 strerrnodef(err), (int)err, strerror(err));
 	}
 
 	if (size + 1 >= sizeof(message)) {


### PR DESCRIPTION
Get the correct error code from errno, instead of TEST_ERRNO.
(TEST_ERRNO is defined in lib/parse_opt.c if #ifdef UNIT_TEST)
