### PR TITLE
kernel: don't wildcard *.sh for linux_syscall_numbers.h

### DIFF
--- a/testcases/kernel/include/Makefile
+++ b/testcases/kernel/include/Makefile
@@ -28,7 +28,7 @@ INSTALL_DIR		:= $(includedir)
 
 MAKE_TARGETS		:= linux_syscall_numbers.h
 
-linux_syscall_numbers.h: $(wildcard $(abs_srcdir)/*.sh $(abs_srcdir)/*.in)
-	$(SHELL) "$(abs_srcdir)/regen.sh"
+linux_syscall_numbers.h: $(abs_srcdir)/regen.sh $(wildcard $(abs_srcdir)/*.in)
+	$(SHELL) "$<"
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk


### PR DESCRIPTION
During a parallel build it's possible that $(wildcard *.sh) evaluates to
"regen.sh linux_syscall_numbers.h.1234.sh", where 1234 is the PID from a
currently executing regen.sh and .sh is the architecture name.  This temporary
file then disappears resulting in "file not found" errors when the dependencies
are evaluated.

The wildcard isn't actually needed as the only script is regen.sh, so hard-code
that into the dependencies (and use $< to reduce duplication).

Signed-off-by: Ross Burton ross.burton@intel.com
