### PR TITLE
Add CROSS_COMPILE symbol to simplify cross-compiling

### DIFF
--- a/include/mk/config.mk.default
+++ b/include/mk/config.mk.default
@@ -24,11 +24,11 @@
 # http://www.gnu.org/software/hello/manual/autoconf/Particular-Programs.html
 
 # Application specifying variables. You should never have to change these.
-AR			:= ar
-CC			:= cc
+AR			:= $(CROSS_COMPILE)ar
+CC			:= $(CROSS_COMPILE)cc
 LEX			:= flex
-RANLIB			:= ranlib
-STRIP			:= strip
+RANLIB			:= $(CROSS_COMPILE)ranlib
+STRIP			:= $(CROSS_COMPILE)strip
 YACC			:= bison -y
 
 #JAR			:= jar


### PR DESCRIPTION
CROSS_COMPILE is a well known symbol for cross-compiling, so add it to simplify
compiling for embeded systems.

Signed-off-by: Zhengwang Ruan rzw@meizu.com
