### PR TITLE
asapi_05: use safe format argument to tst_resm()

### DIFF
--- a/testcases/network/lib6/asapi_05.c
+++ b/testcases/network/lib6/asapi_05.c
@@ -415,7 +415,7 @@ void icmp6_ft(void)
 			tst_resm(TFAIL, "%s: rv %d != expected %d",
 				 ftab[i].ft_tname, rv, ftab[i].ft_expected);
 		else
-			tst_resm(TPASS, ftab[i].ft_tname);
+			tst_resm(TPASS, "%s", ftab[i].ft_tname);
 	}
 }
 


### PR DESCRIPTION
Prior to this pull request, the `asapi_05` test failed to build if `-Werror=format-security` was used. The compiler could not examine the contents of the `ftab` array.

Adjust the `tst_resm` call so that the format string is a string literal.

Fedora recently enabled this compiler option in their RPM builds, so this fixes the build on Fedora 21.
