### PR TITLE
syscalls/ustat: handle not supported syscall

### DIFF
--- a/testcases/kernel/syscalls/ustat/ustat01.c
+++ b/testcases/kernel/syscalls/ustat/ustat01.c
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
 		for (i = 0; i < TST_TOTAL; i++) {
 			TEST(ustat(dev_num, &ubuf));
 
+			if (TEST_RETURN == -1 && TEST_ERRNO == ENOSYS)
+				tst_brkm(TCONF, cleanup, "ustat not supported");
+
 			if (TEST_RETURN == -1) {
 				TEST_ERROR_LOG(TEST_ERRNO);
 				tst_resm(TFAIL, "ustat(2) failed and set"

--- a/testcases/kernel/syscalls/ustat/ustat02.c
+++ b/testcases/kernel/syscalls/ustat/ustat02.c
@@ -72,6 +72,9 @@ int main(int ac, char **av)
 		for (i = 0; i < TST_TOTAL; i++) {
 			TEST(ustat(*tc[i].dev, tc[i].buf));
 
+			if (TEST_RETURN == -1 && TEST_ERRNO == ENOSYS)
+				tst_brkm(TCONF, cleanup, "ustat not supported");
+
 			if ((TEST_RETURN == -1)
 			    && (TEST_ERRNO == tc[i].exp_errno)) {
 				tst_resm(TPASS,


### PR DESCRIPTION
On newer systems (like arm64) this syscall is never present as
architecturally deprecated. Detect it and exit with success.

Signed-off-by: Frediano Ziglio <frediano.ziglio@huawei.com>