### PR TITLE
Cpufreq diotest format strings

### DIFF
--- a/testcases/kernel/device-drivers/cpufreq/cpufreq_boost.c
+++ b/testcases/kernel/device-drivers/cpufreq/cpufreq_boost.c
@@ -152,12 +152,12 @@ static void test_run(void)
 
 	/* Enable boost */
 	if (boost_value == cdrv[id].off)
-		SAFE_FILE_PRINTF(cleanup, cdrv[id].file, cdrv[id].on_str);
+		SAFE_FILE_PRINTF(cleanup, cdrv[id].file, "%s", cdrv[id].on_str);
 	tst_resm(TINFO, "load CPU0 with boost enabled");
 	boost_time = load_cpu(max_freq_khz);
 
 	/* Disable boost */
-	SAFE_FILE_PRINTF(cleanup, cdrv[id].file, cdrv[id].off_str);
+	SAFE_FILE_PRINTF(cleanup, cdrv[id].file, "%s", cdrv[id].off_str);
 	tst_resm(TINFO, "load CPU0 with boost disabled");
 	boost_off_time = load_cpu(max_freq_khz);
 

--- a/testcases/kernel/io/direct_io/diotest4.c
+++ b/testcases/kernel/io/direct_io/diotest4.c
@@ -180,9 +180,9 @@ static void testcheck_end(int ret, int *failed, int *fail_count, char *msg)
 	if (ret != 0) {
 		*failed = TRUE;
 		(*fail_count)++;
-		tst_resm(TFAIL, msg);
+		tst_resm(TFAIL, "%s", msg);
 	} else
-		tst_resm(TPASS, msg);
+		tst_resm(TPASS, "%s", msg);
 }
 
 static void setup(void);


### PR DESCRIPTION
Prior to this pull request, the cpufreq_boost and diotest4 tests failed to build if `-Werror=format-security` was used. The compiler could not examine the contents of the variables to see if they contained format strings or not.

This pull request adjusts the `SAFE_FILE_PRINTF` and `tst_resm` printf wrappers to use the intended format strings.

Fedora recently enabled the `-Werror=format-security` compiler option in their RPM builds, so this fixes the build on Fedora 21.
    
