### PR TITLE
syscalls/ipc: Use kernel and libc compat long type of message type

### DIFF
--- a/testcases/kernel/syscalls/ipc/lib/ipcmsg.h
+++ b/testcases/kernel/syscalls/ipc/lib/ipcmsg.h
@@ -46,7 +46,7 @@ void setup(void);
 #define min(a, b)	(((a) < (b)) ? (a) : (b))
 
 typedef struct mbuf {		/* a generic message structure */
-	long mtype;
+	__syscall_slong_t mtype;
 	char mtext[MSGSIZE + 1];  /* add 1 here so the message can be 1024   */
 } MSGBUF;			  /* characters long with a '\0' termination */
 

--- a/testcases/kernel/syscalls/ipc/lib/libmsgctl.h
+++ b/testcases/kernel/syscalls/ipc/lib/libmsgctl.h
@@ -20,11 +20,13 @@
 #ifndef __LIBMSGCTL_H__
 #define __LIBMSGCTL_H__
 
+#include <sys/types.h>
+
 #define FAIL	1
 #define PASS	0
 
 struct mbuffer {
-	long type;
+	__syscall_slong_t type;
 	struct {
 		char len;
 		char pbytes[99];

--- a/testcases/kernel/syscalls/ipc/msgctl/msgctl07.c
+++ b/testcases/kernel/syscalls/ipc/msgctl/msgctl07.c
@@ -64,7 +64,7 @@ int TST_TOTAL = 1;
 /* Used by main() and do_child_1(): */
 static int msqid;
 struct my_msgbuf {
-	long type;
+	__syscall_slong_t type;
 	char text[BYTES];
 } p1_msgp, p2_msgp, p3_msgp, c1_msgp, c2_msgp, c3_msgp;
 

--- a/testcases/kernel/syscalls/ipc/msgsnd/msgsnd03.c
+++ b/testcases/kernel/syscalls/ipc/msgsnd/msgsnd03.c
@@ -68,7 +68,7 @@ int bad_q = -1;			/* a value to use as a bad queue ID */
 struct test_case_t {
 	int *queue_id;
 	MSGBUF *buffer;
-	long mtype;
+	__syscall_slong_t mtype;
 	int msg_size;
 	int error;
 } TC[] = {


### PR DESCRIPTION
This solves problems in particular on systems with LP64 kernel and ILP32 userland.

Signed-off-by: Kamil Rytarowski <kamil@semihalf.com>