### PR TITLE
fsstress: Fix main loop condition

### DIFF
--- a/testcases/kernel/fs/fsstress/fsstress.c
+++ b/testcases/kernel/fs/fsstress/fsstress.c
@@ -400,7 +400,7 @@ int main(int argc, char **argv)
 
 	make_freq_table();
 
-	while ((loopcntr <= loops) || (loops == 0) && !should_stop) {
+	while (((loopcntr <= loops) || (loops == 0)) && !should_stop) {
 		if (!dirname) {
 			/* no directory specified */
 			if (!nousage)


### PR DESCRIPTION
The semantics of the previous form of the condition did not make
sense, as should_stop was only respected when loops == 0. This
looks like a simple mistake with operator precedence.