### PR TITLE
Avoid the following warning when the ltp is built.

### DIFF
--- a/testcases/kernel/containers/pidns/pidns01.c
+++ b/testcases/kernel/containers/pidns/pidns01.c
@@ -68,7 +68,7 @@ int TST_TOTAL = 1;
 /*
  * child_fn1() - Inside container
  */
-int child_fn1(void *ttype)
+int child_fn1(void *ttype LTP_ATTRIBUTE_UNUSED)
 {
 	int exit_val;
 	pid_t cpid, ppid;
@@ -97,7 +97,7 @@ static void setup(void)
 int main(int argc, char *argv[])
 {
 	int status;
-
+	tst_parse_opts(argc, argv, NULL, NULL);
 	setup();
 
 	TEST(do_clone_unshare_test(T_CLONE, CLONE_NEWPID, child_fn1, NULL));
@@ -119,6 +119,6 @@ int main(int argc, char *argv[])
 	tst_exit();
 }
 
-static void cleanup()
+static void cleanup(void)
 {
 }


### PR DESCRIPTION
pidns01.c: In function ?.hild_fn1?.
pidns01.c:62:21: warning: unused parameter ?.type?.[-Wunused-parameter]
int child_fn1(void *ttype)
                         ^
pidns01.c: In function ?.ain?.
pidns01.c:98:2: warning: implicit declaration of function ?.ait?.[-Wimplicit-function-declaration]
pidns01.c:88:14: warning: unused parameter ?.rgc?.[-Wunused-parameter]
int main(int argc, char *argv[])
                  ^
                              ^
pidns01.c: In function ?.leanup?.
pidns01.c:113:13: warning: old-style function definition [-Wold-style-definition]
static void cleanup()

Signed-off-by: Yuan Sun <sunyuan3@huawei.com>