### PR TITLE
Fix out-of-tree build of numa_helper

### DIFF
--- a/testcases/kernel/lib/Makefile
+++ b/testcases/kernel/lib/Makefile
@@ -22,7 +22,8 @@ top_srcdir		?= ../../..
 
 include $(top_srcdir)/include/mk/env_pre.mk
 
-CPPFLAGS		+= $(NUMA_CPPFLAGS) -I$(abs_srcdir)/../include
+CPPFLAGS		+= $(NUMA_CPPFLAGS) -I$(abs_srcdir)/../include \
+			   -I$(abs_builddir)/../include
 INTERNAL_LIB		:= libkerntest.a
 
 include $(top_srcdir)/include/mk/lib.mk


### PR DESCRIPTION
This patch adds an include search path to the CPPFLAGS for
numa_helper.c to locate header files generated earlier in the build
process for out-of-tree builds.

The linux_syscall_numbers.h header file is generated during the
build process into the build directory. The CPPFLAGS to build
testcases/kernel/lib/numa_helper.c however don't provide the build
directory as an include search path.