### PR TITLE
_GNU_SOURCE should be defined for fanotify tests

### DIFF
--- a/testcases/kernel/syscalls/fanotify/fanotify01.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify01.c
@@ -25,6 +25,7 @@
  * DESCRIPTION
  *     Check that fanotify work for a file
  */
+#define _GNU_SOURCE
 #include "config.h"
 
 #include <stdio.h>

--- a/testcases/kernel/syscalls/fanotify/fanotify02.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify02.c
@@ -25,6 +25,7 @@
  * DESCRIPTION
  *     Check that fanotify work for children of a directory
  */
+#define _GNU_SOURCE
 #include "config.h"
 
 #include <stdio.h>

--- a/testcases/kernel/syscalls/fanotify/fanotify03.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify03.c
@@ -25,6 +25,7 @@
  * DESCRIPTION
  *     Check that fanotify permission events work
  */
+#define _GNU_SOURCE
 #include "config.h"
 
 #include <stdio.h>

--- a/testcases/kernel/syscalls/fanotify/fanotify04.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify04.c
@@ -25,6 +25,8 @@
  * DESCRIPTION
  *     Check various fanotify special flags
  */
+
+#define _GNU_SOURCE
 #include "config.h"
 
 #include <stdio.h>


### PR DESCRIPTION
Needed for uClibc-ng/uClibc to define O_DIRECTORY.

Signed-off-by: Waldemar Brodkorb <wbx@openadk.org>