### PR TITLE
madvise: New MADV_HWPOISON and MADV_DONTDUMP tests

### DIFF
--- a/testcases/kernel/syscalls/.gitignore
+++ b/testcases/kernel/syscalls/.gitignore
@@ -506,6 +506,8 @@
 /madvise/madvise04
 /madvise/madvise05
 /madvise/madvise06
+/madvise/madvise07
+/madvise/madvise08
 /mallopt/mallopt01
 /mbind/mbind01
 /memcmp/memcmp01


### PR DESCRIPTION
Two new tests for the madvise system call's MADV_HWPOISON, MADV_DONTDUMP and
MADV_DODUMP flags.

madvise07.c
-----
Checks if SIGBUS is raised after memory is marked
	     with MADV_HWPOISON.
madvise08.c
-----
  Checks that memory marked with MADV_DONTDUMP is not
	     included in a core dump. Also checks if the same memory
	     then marked with MADV_DODUMP is included in a core dump.

Signed-off-by: Richard Palethorpe <richiejp@f-m.fm>