### PR TITLE
Modified kdump to solve compilation issue and added support for ubuntu.

### DIFF
--- a/testcases/kdump/lib/crasher/crasher.c
+++ b/testcases/kdump/lib/crasher/crasher.c
@@ -46,7 +46,7 @@ static int crasher_read(char *buf, char **start, off_t offset, int len,
 }
 
 static int crasher_write(struct file *file, const char *buffer,
-			 unsigned long count, void *data)
+			unsigned long count, void *data)
 {
 	char value, *a;
 	DEFINE_SPINLOCK(mylock);
@@ -82,6 +82,10 @@ static int crasher_write(struct file *file, const char *buffer,
 				   somtimes white lies are ok */
 }
 
+struct file_operations proc_fops = {
+	.write = crasher_write
+};
+
 /* create a directory in /proc and a debug file in the new directory */
 
 int crasher_init(void)
@@ -89,7 +93,7 @@ int crasher_init(void)
 	struct proc_dir_entry *crasher_proc;
 
 	printk("loaded crasher module\n");
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0)
 	/* build a crasher file that can be set */
 	if ((crasher_proc = create_proc_entry(CRASH, 0, NULL)) == NULL) {
 		return -ENOMEM;
@@ -99,6 +103,9 @@ int crasher_init(void)
 #endif
 	crasher_proc->read_proc = crasher_read;
 	crasher_proc->write_proc = crasher_write;
+#else
+	proc_create(CRASH, 0, NULL, &proc_fops);
+#endif
 	return 0;
 }
 

--- a/testcases/kdump/lib/lkdtm/lkdtm.c
+++ b/testcases/kdump/lib/lkdtm/lkdtm.c
@@ -311,6 +311,8 @@ int lkdtm_module_init(void)
 	switch (cpoint) {
 	case INT_HARDWARE_ENTRY:
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 32)
+
 #ifdef USE_SYMBOL_NAME
 
 #ifdef __powerpc__
@@ -323,6 +325,22 @@ int lkdtm_module_init(void)
 		lkdtm_lookup_name("__do_IRQ", (void (*)(void))jp_do_irq);
 
 #endif /* USE_SYMBOL_NAME */
+
+#else
+
+#ifdef USE_SYMBOL_NAME
+
+#ifdef __powerpc__
+		lkdtm_symbol_name(".do_IRQ", (void (*)(void))jp_do_irq);
+#else
+		lkdtm_symbol_name("do_IRQ", (void (*)(void))jp_do_irq);
+#endif /*__powerpc__*/
+
+#else /* USE_SYMBOL_NAME */
+		lkdtm_lookup_name("do_IRQ", (void (*)(void))jp_do_irq);
+
+#endif /* USE_SYMBOL_NAME */
+#endif
 		break;
 
 	case INT_HW_IRQ_EN:

--- a/testcases/kdump/runkdump.sh
+++ b/testcases/kdump/runkdump.sh
@@ -23,6 +23,8 @@ EOF
 
     if [ -f /etc/init.d/crond ]; then
         cron=crond
+    elif [ -f /etc/sysconfig/crond ]; then
+        cron=crond
     else
         # SUSE
         cron=cron
@@ -41,7 +43,9 @@ EOF
 SetupKdump ()
 {
     echo "Start kdump daemon."
-    /etc/init.d/kdump restart
+    if [ -x "/etc/init.d/kdump" ]; then
+        /etc/init.d/kdump restart
+    fi
 
     echo "Enable kdump daemon by default."
     # Red Hat and SUSE.
@@ -52,8 +56,12 @@ SetupKdump ()
     elif [ -x "/sbin/update-rc.d" ]; then
         /sbin/update-rc.d kdump defaults
     fi
-}
 
+    # Ubuntu
+    if [ -x "/etc/init.d/kdump-tools" ]; then
+        /etc/init.d/kdump-tools restart
+    fi
+}
 
 PrepareVerify ()
 {
@@ -116,7 +124,11 @@ PrepareVerify ()
         COREDIR=/mnt"${COREDIR}"
     fi
 
-    vmcore=$(ls -t "${COREDIR}"/*/vmcore* 2>/dev/null | head -1)
+    if [ `cut -d'"' -f2 /etc/os-release | head -1` == "Ubuntu" ]; then
+        vmcore=$(ls -t "${COREDIR}"/*/dump* 2>/dev/null | head -1)
+    else
+        vmcore=$(ls -t "${COREDIR}"/*/vmcore* 2>/dev/null | head -1)
+    fi
 }
 
 VerifyTest ()


### PR DESCRIPTION
1. Modified crasher.c for kernel version greater than 3.10.
   Since create_proc_entry and proc_dir_entry are deprecated in latest
   kernel modified crasher.c using proc_create.
2. Modified setup.sh and runkdump.sh to support Ubuntu.
3. Modified lkdtm.c to use do_IRQ instead of __do_IRQ.
