### PR TITLE
open/open04.c: fix memory leak by freeing the buf

### DIFF
--- a/testcases/kernel/syscalls/open/open04.c
+++ b/testcases/kernel/syscalls/open/open04.c
@@ -126,6 +126,8 @@ static void cleanup(void)
 		unlink(fname);
 	}
 
+	free(buf);
+
 	/* delete the test directory created in setup() */
 	tst_rmdir();
 }


### PR DESCRIPTION
The test was leaking some memory because of missing `free()` call during cleanup.