### PR TITLE
runltplite.sh: Adding SKIPFILE option and few minor fixes

### DIFF
--- a/runltplite.sh
+++ b/runltplite.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 ################################################################################
 ##                                                                            ##
 ## Copyright (c) International Business Machines  Corp., 2001,2005            ##
@@ -26,16 +26,16 @@
 # Authors:      Manoj Iyer - manoji@us.ibm.com
 #               Robbie Williamson - robbiew@us.ibm.com
 #               Marty Ridgeway - mridge@us.ibm.com
-#               
+#
 # History:      Created runltplite script to run a subset of the LTP testsuite
-#               
-#               
-#               
-#                
-#               
-#               
-#               
-#               
+#
+#
+#
+#
+#
+#
+#
+#
 
 
 setup()
@@ -66,23 +66,24 @@ setup()
 }
 
 
-usage() 
+usage()
 {
     cat <<-EOF >&2
 
-    usage: ${0##*/} -c [-d TMPDIR] [-i # (in Mb)] 
-    [ -l LOGFILE ] [ -o OUTPUTFILE ] [ -m # (in Mb)] -N -q 
-    [ -r LTPROOT ] -v 
-                
+    usage: ${0##*/} -c [-d TMPDIR] [-i # (in Mb)]
+    [ -l LOGFILE ] [ -o OUTPUTFILE ] [ -m # (in Mb)] -N -q
+    [ -r LTPROOT ] -v
+
     -c NUM_PROCS    Run LTP under additional background CPU load.
     -d TMPDIR       Directory where temporary files will be created.
     -h              Help. Prints all available options.
     -i # (in Mb)    Run LTP with a _min_ IO load of # Mb in background.
     -l LOGFILE      Log results of test in a logfile.
     -m # (in Mb)    Run LTP with a _min_ memory load of # Mb in background.
-    -N              Run all the networking tests. 
+    -N              Run all the networking tests.
+    -S SKIPFILE     Skip tests specified in SKIPFILE
     -o OUTPUTFILE   Redirect test output to a file.
-    -p              Human readable format logfiles. 
+    -p              Human readable format logfiles.
     -q              Print less verbose output to screen.
     -r LTPROOT      Fully qualified path where testsuite is installed.
 
@@ -114,29 +115,29 @@ main()
 
     local scenfile=""
 
-    while getopts c:d:hi:l:m:No:pqr: arg
+    while getopts c:d:hi:l:m:No:pqrS: arg
     do  case $arg in
-        c)       
+        c)
 	    NUM_PROCS=$(($OPTARG))
             $LTPROOT/testcases/bin/genload --cpu $NUM_PROCS >/dev/null 2>&1 &
             GENLOAD=1 ;;
-                   
-        d)  # append $$ to TMP, as it is recursively 
+
+        d)  # append $$ to TMP, as it is recursively
             # removed at end of script.
             TMPBASE=$OPTARG
             TMP="${TMPBASE}/ltp-$$"
             export TMPDIR="$TMP";;
-    
+
         h)  usage;;
-        
-        i)       
+
+        i)
             BYTESIZE=$(($OPTARG * 1024 * 1024))
             $LTPROOT/testcases/bin/genload --io 1 >/dev/null 2>&1 &
             $LTPROOT/testcases/bin/genload --hdd 0 --hdd-bytes $BYTESIZE \
-            >/dev/null 2>&1 & 
+            >/dev/null 2>&1 &
             GENLOAD=1 ;;
-    
-        l)      
+
+        l)
 
             [ ! -d $LTPROOT/results ] && \
             {
@@ -150,38 +151,45 @@ main()
             case $OPTARG in
 	    /*)
                 LOGFILE="-l $OPTARG" ;;
-            *)    
+            *)
                 LOGFILE="-l $LTPROOT/results/$OPTARG"
                 ALT_DIR=1 ;;
             esac ;;
-    
-        m)      
-            MEMSIZE=$(($OPTARG * 1024 * 1024)) 
+
+        m)
+            MEMSIZE=$(($OPTARG * 1024 * 1024))
             $LTPROOT/testcases/bin/genload  --vm 0 --vm-bytes $MEMSIZE \
-                >/dev/null 2>&1 & 
+                >/dev/null 2>&1 &
             GENLOAD=1;;
-    
+
         N)  RUN_NETEST=1;;
-    
+
         o)  OUTPUTFILE="-o $OPTARG" ;;
-    
+
         p)  PRETTY_PRT=" -p ";;
-   
+
         q)  QUIET_MODE=" -q ";;
-    
+
         r)  LTPROOT=$OPTARG;;
-    
+
+        S)  case $OPTARG in
+                /*)
+                    SKIPFILE=$OPTARG;;
+                *)
+                    SKIPFILE="$LTPROOT/$OPTARG";;
+            esac ;;
+
         \?) usage;;
         esac
     done
-    
-        
+
+
     mkdir -p $TMP || \
     {
         echo "FATAL: Unable to make temporary directory $TMP"
         exit 1
     }
-    
+
     cd $TMP || \
     {
       echo "could not cd ${TMP} ... exiting"
@@ -189,7 +197,7 @@ main()
     }
 
 # Run Networking tests ?
-    
+
     [ "$RUN_NETEST" -eq 1 ] && \
     {
         [ -z "$RHOST" ] || [ -z "$PASSWD" ] && \
@@ -215,7 +223,7 @@ main()
             echo "WARNING: security of $RHOST may be compromised"
         }
     }
-    
+
     # If user does not provide a command file select a default set of testcases
     # to execute.
     if   [ -f $CMDFILE ] || \
@@ -231,7 +239,7 @@ main()
     if [ "$RUN_NETEST" -eq 1 ]; then
         SCENARIO_LISTS="$SCENARIO_LISTS $LTPROOT/scenario_groups/network"
     fi
- 
+
     # DO NOT INDENT/DEDENT!
         if [ -n "$SCENARIO_LISTS" ]; then
             # Insurance to make sure that the first element in the pipe
@@ -262,7 +270,7 @@ main()
     # ^^DO NOT INDENT/DEDENT!^^
 
     # The fsx-linux tests use the SCRATCHDEV environment variable as a location
-    # that can be reformatted and run on.  Set SCRATCHDEV if you want to run 
+    # that can be reformatted and run on.  Set SCRATCHDEV if you want to run
     # these tests.  As a safeguard, this is disabled.
     unset SCRATCHDEV
     [ -n "$SCRATCHDEV" ] && \
@@ -273,14 +281,14 @@ main()
              exit 1
          }
     }
-    
+
     # check for required users and groups
     ${LTPROOT}/IDcheck.sh &>/dev/null || \
     {
         echo "WARNING: required users and groups not present"
         echo "WARNING: some test cases may fail"
     }
-    
+
     [ -n "$CMDFILES" ] && \
     {
         for scenfile in `echo "$CMDFILES" | tr ',' ' '`
@@ -294,10 +302,18 @@ main()
             }
         done
     }
- 
+
+    # Blacklist or skip tests if a SKIPFILE was specified with -S
+    if [ -n "$SKIPFILE" ]
+    then
+        for file in $( cat $SKIPFILE ); do
+            sed -i "/^$file[ \t]/d" ${TMP}/alltests
+        done
+    fi
+
     # display versions of installed software
     [ -z "$QUIET_MODE" ] && \
-    { 
+    {
         ${LTPROOT}/ver_linux || \
         {
             echo "WARNING: unable to display versions of software installed"
@@ -319,7 +335,7 @@ main()
     cd "${LTPROOT}/testcases/bin"
     ${LTPROOT}/bin/ltp-pan $QUIET_MODE -e -S $INSTANCES $DURATION -a $$ \
     -n $$ $PRETTY_PRT -f ${TMP}/alltests $LOGFILE $OUTPUTFILE
-    
+
     if [ $? -eq 0 ]; then
       echo "INFO: ltp-pan reported all tests PASS"
       VALUE=0
@@ -329,21 +345,21 @@ main()
     fi
     cd ..
     [ ! -z "$QUIET_MODE" ] && { echo "INFO: Test end time: $(date)" ; }
-    
+
     [ "$GENLOAD" -eq 1 ] && { killall -9 genload ; }
     [ "$NETPIPE" -eq 1 ] && { killall -9 NPtcp ; }
-    
+
     [ "$ALT_DIR" -eq 1 ] && \
     {
     cat <<-EOF >&1
-        
+
        ###############################################################"
-        
+
             Done executing testcases."
             result log is in the $LTPROOT/results directory"
-        
+
        ###############################################################"
-       
+
 	EOF
     }
     exit $VALUE


### PR DESCRIPTION
Though it already runs subtest of tests with a
defined scenario file, it would be good to have
the skip tests options for the user for more flexibility
at run time.
Fixed minor whitespace issues.