### PR TITLE
runltplite: fix the "-r" option

### DIFF
--- a/runltplite.sh
+++ b/runltplite.sh
@@ -122,7 +122,7 @@ main()
 
     local scenfile=""
 
-    while getopts c:d:hi:l:m:No:pqrS:b:B: arg
+    while getopts c:d:hi:l:m:No:pqr:S:b:B: arg
     do  case $arg in
         c)
 	    NUM_PROCS=$(($OPTARG))


### PR DESCRIPTION
The "-r" option has a argument. This bug is introduced by
PR #78 .

Signed-off-by: Wanlong Gao <wanlong.gao@gmail.com>