### PR TITLE
rt_sigaction.h: Add MIPS support

### DIFF
--- a/include/lapi/rt_sigaction.h
+++ b/include/lapi/rt_sigaction.h
@@ -33,15 +33,23 @@
 
 #define INVAL_SA_PTR ((void *)-1)
 
+#if defined(__mips__)
+struct kernel_sigaction {
+	unsigned int sa_flags;
+	__sighandler_t k_sa_handler;
+	sigset_t sa_mask;
+};
+#else
 struct kernel_sigaction {
 	__sighandler_t k_sa_handler;
 	unsigned long sa_flags;
 	void (*sa_restorer) (void);
 	sigset_t sa_mask;
 };
+#endif
 
 /* This macro marks if (struct sigaction) has .sa_restorer member */
-#if !defined(__ia64__) && !defined(__alpha__) && !defined(__hppa__)
+#if !defined(__ia64__) && !defined(__alpha__) && !defined(__hppa__) && !defined(__mips__)
 # define HAVE_SA_RESTORER
 #endif
 
@@ -190,8 +198,9 @@ static int ltp_rt_sigaction(int signum, const struct sigaction *act,
 		kact.k_sa_handler = act->sa_handler;
 		memcpy(&kact.sa_mask, &act->sa_mask, sizeof(sigset_t));
 		kact.sa_flags = act->sa_flags;
+#ifndef __mips__
 		kact.sa_restorer = NULL;
-
+#endif
 		kact_p = &kact;
 	}
 

--- a/testcases/kernel/controllers/memcg/control/memcg_control_test.sh
+++ b/testcases/kernel/controllers/memcg/control/memcg_control_test.sh
@@ -116,7 +116,7 @@ result()
 cleanup()
 {
 	if [ -e $TST_PATH/mnt ]; then
-		umount $TST_PATH/mnt 2> /dev/null
+		umount -l $TST_PATH/mnt 2> /dev/null
 		rm -rf $TST_PATH/mnt
 	fi
 }

--- a/testcases/kernel/mem/tunable/max_map_count.c
+++ b/testcases/kernel/mem/tunable/max_map_count.c
@@ -63,7 +63,7 @@
 #include "test.h"
 #include "mem.h"
 
-#define MAP_COUNT_DEFAULT	64
+#define MAP_COUNT_DEFAULT	1024
 #define MAX_MAP_COUNT		65536L
 
 char *TCID = "max_map_count";
@@ -247,6 +247,6 @@ static void max_map_count_test(void)
 		if (waitpid(pid, &status, 0) == -1)
 			tst_brkm(TBROK | TERRNO, cleanup, "waitpid");
 
-		max_maps = max_maps << 2;
+		max_maps = max_maps << 1;
 	}
 }

--- a/testscripts/test_fs_bind.sh
+++ b/testscripts/test_fs_bind.sh
@@ -498,6 +498,7 @@ main()
 			((TST_COUNT++))
 		done
 	done
+	rm -rf "${resdir}"
 	rm -rf "${sandbox}"
 	return 0
 


### PR DESCRIPTION
MIPS's kernel sigaction is different from most architectures. If
without this patch, rt_sigaction01 will get a segfault on MIPS.

Signed-off-by: Huacai Chen <chenhc@lemote.com>