### PR TITLE
runltp: Fix export assignment for Dash

### DIFF
--- a/runltp
+++ b/runltp
@@ -876,8 +876,8 @@ main()
 
     if [ "$ALT_HTML_OUT" -eq 1 ] ; then        #User wants the HTML output to be created, it then needs to be generated
        export LTP_VERSION=$version_date
-       export TEST_START_TIME=$test_start_time
-       export TEST_END_TIME=$(date)
+       export TEST_START_TIME="$test_start_time"
+       export TEST_END_TIME="$(date)"
        OUTPUT_DIRECTORY=`echo $OUTPUTFILE | cut -c4-`
        LOGS_DIRECTORY="$LTPROOT/results"
        export TEST_OUTPUT_DIRECTORY="$LTPROOT/output"


### PR DESCRIPTION
When we try to create hlml file on Dash it is failed. The runltp.sh try to save
the start time and the end time by `date.` But the value of `date` contains some
whitespaces and Dash split the value base on whitespace. So the assignment by
export fails. It looks Dash's bug but we can write 'export="${date}" as a manner.
Bash does not perform splitting on export, local and readonly so it works well on
Bash.

Signed-off-by: Jungsu Sohn <jsson98@gmail.com>