### PR TITLE
open_posix_testsuite: sched_setscheduler returns previous policy

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/sched_setparam/23-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sched_setparam/23-2.c
@@ -38,7 +38,7 @@ int main(void)
 		perror("An error occurs when calling sched_getscheduler()");
 		return PTS_UNRESOLVED;
 	} else if (policy != SCHED_SPORADIC) {
-		if (sched_setscheduler(0, SCHED_SPORADIC, &param) != 0) {
+		if (sched_setscheduler(0, SCHED_SPORADIC, &param) == -1) {
 			perror("An error occurs when calling sched_getparam()");
 			return PTS_UNRESOLVED;
 		}

--- a/testcases/open_posix_testsuite/conformance/interfaces/sched_setparam/25-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sched_setparam/25-2.c
@@ -39,7 +39,7 @@ int main(void)
 			return PTS_UNRESOLVED;
 		}
 
-		if (sched_setscheduler(0, SCHED_SPORADIC, &param) != 0) {
+		if (sched_setscheduler(0, SCHED_SPORADIC, &param) == -1) {
 			perror("An error occurs when calling sched_getparam()");
 			return PTS_UNRESOLVED;
 		}

--- a/testcases/open_posix_testsuite/conformance/interfaces/sched_setparam/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sched_setparam/9-1.c
@@ -140,7 +140,7 @@ int main(void)
 	*shmptr = 0;
 
 	param.sched_priority = sched_get_priority_min(SCHED_FIFO);
-	if (sched_setscheduler(getpid(), SCHED_FIFO, &param) != 0) {
+	if (sched_setscheduler(getpid(), SCHED_FIFO, &param) == -1) {
 		if (errno == EPERM) {
 			printf("This process does not have the permission"
 			       " to set its own scheduling parameter.\n"

--- a/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/15-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/15-1.c
@@ -57,7 +57,7 @@ int main(void)
 	}
 
 	param.sched_priority = sched_get_priority_min(new_policy);
-	if (sched_setscheduler(getpid(), new_policy, &param) != 0) {
+	if (sched_setscheduler(getpid(), new_policy, &param) == -1) {
 		if (errno == EPERM) {
 			printf
 			    ("This process does not have the permission to set its own scheduling policy.\nTry to launch this test as root.\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/15-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/15-2.c
@@ -63,7 +63,7 @@ int main(void)
 	}
 
 	param.sched_priority = new_priority;
-	if (sched_setscheduler(getpid(), SCHED_FIFO, &param) != 0) {
+	if (sched_setscheduler(getpid(), SCHED_FIFO, &param) == -1) {
 		if (errno == EPERM) {
 			printf
 			    ("This process does not have the permission to set its own scheduling policy.\nTry to launch this test as root.\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/22-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/22-1.c
@@ -45,7 +45,7 @@ int main(void)
 	    SCHED_RR : SCHED_FIFO;
 
 	param.sched_priority = sched_get_priority_min(new_policy);
-	if (sched_setscheduler(getpid(), new_policy, &param) != 0) {
+	if (sched_setscheduler(getpid(), new_policy, &param) == -1) {
 		if (errno == EPERM) {
 			printf
 			    ("This process does not have the permission to set its own scheduling policy.\nTry to launch this test as root.\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/22-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sched_setscheduler/22-2.c
@@ -44,7 +44,7 @@ int main(void)
 	new_priority = (param.sched_priority == max_priority) ?
 	    sched_get_priority_min(SCHED_FIFO) : max_priority;
 	param.sched_priority = new_priority;
-	if (sched_setscheduler(getpid(), SCHED_FIFO, &param) != 0) {
+	if (sched_setscheduler(getpid(), SCHED_FIFO, &param) == -1) {
 		if (errno == EPERM) {
 			printf
 			    ("This process does not have the permission to set its own scheduling policy.\nTry to launch this test as root.\n");


### PR DESCRIPTION
POSIX specifies that sched_setscheduler() returns the value of the
previous scheduling policy on success, and -1 on failure. But Linux
always returns 0 on success. Check for a return value of -1 so these
tests can run on other platforms.