### PR TITLE
It is more safer to use "unsigned long" when we transfer "void *".

### DIFF
--- a/testcases/kernel/syscalls/brk/brk01.c
+++ b/testcases/kernel/syscalls/brk/brk01.c
@@ -54,8 +54,8 @@ void cleanup();
 char *TCID = "brk01";
 int TST_TOTAL = 1;
 
-long Max_brk_byte_size;
-long Beg_brk_val;
+unsigned long Max_brk_byte_size;
+unsigned long Beg_brk_val;
 
 #if !defined(UCLINUX)
 
@@ -64,8 +64,8 @@ int main(int ac, char **av)
 	int lc;
 	int incr;
 	long nbrkpt;		/* new brk point value */
-	long cur_brk_val;	/* current size returned by sbrk */
-	long aft_brk_val;	/* current size returned by sbrk */
+	unsigned long cur_brk_val;	/* current size returned by sbrk */
+	unsigned long aft_brk_val;	/* current size returned by sbrk */
 
 	tst_parse_opts(ac, av, NULL, NULL);
 
@@ -90,7 +90,7 @@ int main(int ac, char **av)
 		 * every odd lc value, strink by one incr.
 		 * If lc is equal to 3, no change, special case.
 		 */
-		cur_brk_val = (long)sbrk(0);
+		cur_brk_val = (unsigned long)sbrk(0);
 		if (lc == 3) {
 			nbrkpt = cur_brk_val;	/* no change, special one time case */
 		} else if ((lc % 2) == 0) {
@@ -118,13 +118,13 @@ int main(int ac, char **av)
 
 		if (TEST_RETURN == -1) {
 
-			aft_brk_val = (long)sbrk(0);
+			aft_brk_val = (unsigned long)sbrk(0);
 			tst_resm(TFAIL | TTERRNO,
 				 "brk(%ld) failed (size before %ld, after %ld)",
 				 nbrkpt, cur_brk_val, aft_brk_val);
 
 		} else {
-			aft_brk_val = (long)sbrk(0);
+			aft_brk_val = (unsigned long)sbrk(0);
 			if (aft_brk_val == nbrkpt) {
 
 				tst_resm(TPASS,
@@ -187,7 +187,7 @@ void setup(void)
 	if (max_size > (usr_mem_sz / 4))
 		max_size = usr_mem_sz / 4;	/* only fourth mem by single test */
 
-	Beg_brk_val = (long)sbrk(0);
+	Beg_brk_val = (unsigned long)sbrk(0);
 
 	/*
 	 * allow at least 4 times a big as current.

--- a/testcases/kernel/syscalls/fchmod/fchmod01.c
+++ b/testcases/kernel/syscalls/fchmod/fchmod01.c
@@ -163,7 +163,7 @@ void setup(void)
 	sprintf(fname, "tfile_%d", getpid());
 	if ((fd = open(fname, O_RDWR | O_CREAT, 0700)) == -1)
 		tst_brkm(TBROK | TERRNO, cleanup, "open failed");
-	else if (write(fd, &buf, strlen(buf)) == -1)
+	else if (write(fd, buf, strlen(buf)) == -1)
 		tst_brkm(TBROK | TERRNO, cleanup, "write failed");
 }
 


### PR DESCRIPTION
When I run this test in edison(32-bit),it will reports as follows:

brk01       1  TFAIL  :  brk01.c:137: brk(-1942200368) returned 0, sbrk before -1936150528, after -1936150528

So I think it is more safer to use "unsigned long"