### PR TITLE
It is safer to use "uintptr_t" when we transfer "void *".

### DIFF
--- a/testcases/kernel/syscalls/brk/brk01.c
+++ b/testcases/kernel/syscalls/brk/brk01.c
@@ -39,6 +39,8 @@
 #include <signal.h>
 #include <sys/param.h>
 #include <sys/resource.h>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "test.h"
 
@@ -54,8 +56,8 @@ void cleanup();
 char *TCID = "brk01";
 int TST_TOTAL = 1;
 
-long Max_brk_byte_size;
-long Beg_brk_val;
+uintptr_t Max_brk_byte_size;
+uintptr_t Beg_brk_val;
 
 #if !defined(UCLINUX)
 
@@ -63,9 +65,9 @@ int main(int ac, char **av)
 {
 	int lc;
 	int incr;
-	long nbrkpt;		/* new brk point value */
-	long cur_brk_val;	/* current size returned by sbrk */
-	long aft_brk_val;	/* current size returned by sbrk */
+	uintptr_t nbrkpt;		/* new brk point value */
+	uintptr_t cur_brk_val;	/* current size returned by sbrk */
+	uintptr_t aft_brk_val;	/* current size returned by sbrk */
 
 	tst_parse_opts(ac, av, NULL, NULL);
 
@@ -90,7 +92,7 @@ int main(int ac, char **av)
 		 * every odd lc value, strink by one incr.
 		 * If lc is equal to 3, no change, special case.
 		 */
-		cur_brk_val = (long)sbrk(0);
+		cur_brk_val = (uintptr_t)sbrk(0);
 		if (lc == 3) {
 			nbrkpt = cur_brk_val;	/* no change, special one time case */
 		} else if ((lc % 2) == 0) {
@@ -118,21 +120,21 @@ int main(int ac, char **av)
 
 		if (TEST_RETURN == -1) {
 
-			aft_brk_val = (long)sbrk(0);
+			aft_brk_val = (uintptr_t)sbrk(0);
 			tst_resm(TFAIL | TTERRNO,
-				 "brk(%ld) failed (size before %ld, after %ld)",
+				 "brk(%"PRIuPTR") failed (size before %"PRIuPTR", after %"PRIuPTR")",
 				 nbrkpt, cur_brk_val, aft_brk_val);
 
 		} else {
-			aft_brk_val = (long)sbrk(0);
+			aft_brk_val = (uintptr_t)sbrk(0);
 			if (aft_brk_val == nbrkpt) {
 
 				tst_resm(TPASS,
-					 "brk(%ld) returned %ld, new size verified by sbrk",
+					 "brk(%"PRIuPTR") returned %"PRIuPTR", new size verified by sbrk",
 					 nbrkpt, TEST_RETURN);
 			} else {
 				tst_resm(TFAIL,
-					 "brk(%ld) returned %ld, sbrk before %ld, after %ld",
+					 "brk(%"PRIuPTR") returned %"PRIuPTR", sbrk before %"PRIuPTR", after %"PRIuPTR"",
 					 nbrkpt, TEST_RETURN,
 					 cur_brk_val, aft_brk_val);
 			}
@@ -187,7 +189,7 @@ void setup(void)
 	if (max_size > (usr_mem_sz / 4))
 		max_size = usr_mem_sz / 4;	/* only fourth mem by single test */
 
-	Beg_brk_val = (long)sbrk(0);
+	Beg_brk_val = (uintptr_t)sbrk(0);
 
 	/*
 	 * allow at least 4 times a big as current.


### PR DESCRIPTION
And  I use "%"PRIuPTR"" to replace "%ld" as Mike's advices.