### PR TITLE
fchmod01:use "buf" to replace "&buf"

### DIFF
--- a/testcases/kernel/syscalls/fchmod/fchmod01.c
+++ b/testcases/kernel/syscalls/fchmod/fchmod01.c
@@ -163,7 +163,7 @@ void setup(void)
 	sprintf(fname, "tfile_%d", getpid());
 	if ((fd = open(fname, O_RDWR | O_CREAT, 0700)) == -1)
 		tst_brkm(TBROK | TERRNO, cleanup, "open failed");
-	else if (write(fd, &buf, strlen(buf)) == -1)
+	else if (write(fd, buf, strlen(buf)) == -1)
 		tst_brkm(TBROK | TERRNO, cleanup, "write failed");
 }
 


### PR DESCRIPTION
Because the type of buf is "char *",so it is correctly to use "buf"
directly.

Signed-off-by Kun Yan  <samyankun@gmail.com>