### PR TITLE
fsync/fsync01: Use the correct parameters while calling write

### DIFF
--- a/testcases/kernel/syscalls/fsync/fsync01.c
+++ b/testcases/kernel/syscalls/fsync/fsync01.c
@@ -139,7 +139,7 @@ int main(int ac, char **av)
 
 		tst_count = 0;
 
-		if (write(fd, &buf, strlen(buf)) == -1)
+		if (write(fd, buf, strlen(buf)) == -1)
 			tst_brkm(TBROK | TERRNO, cleanup, "write failed");
 		TEST(fsync(fd));
 


### PR DESCRIPTION
What we need is a string pointer not an address of a string pointer
for calling "write(...)".

Signed-off-by: gyher <yahu.gao@intel.com>