### PR TITLE
open_posix_testsuite: intialize var for VLA

### DIFF
--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
@@ -230,6 +230,7 @@ void *thread_tb(void *arg)
 
 int main(int argc, char **argv)
 {
+	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1], threadsample, threadtp, threadtl, threadtb;
@@ -239,7 +240,6 @@ int main(int argc, char **argv)
 	int rc;
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 6);
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	base_time = seconds_read();
 
 	/* Initialize a mutex with PTHREAD_PRIO_INHERIT protocol */

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
@@ -255,6 +255,7 @@ void *thread_tb2(void *arg)
 
 int main(int argc, char **argv)
 {
+	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1];
@@ -265,7 +266,6 @@ int main(int argc, char **argv)
 	int rc;
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 8);
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	base_time = seconds_read();
 
 	/* Initialize a mutex with PTHREAD_PRIO_INHERIT protocol */

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
@@ -266,6 +266,7 @@ void *thread_tb2(void *arg)
 
 int main(int argc, char **argv)
 {
+	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1];
@@ -277,7 +278,6 @@ int main(int argc, char **argv)
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 8);
 	base_time = seconds_read();
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 
 	/* Initialize mutex1, mutex2 with PTHREAD_PRIO_INHERIT protocol */
 	mutex_attr_init(&mutex_attr);

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
@@ -236,6 +236,7 @@ void *thread_tb2(void *arg)
 
 int main(int argc, char **argv)
 {
+	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1];
@@ -247,7 +248,6 @@ int main(int argc, char **argv)
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 8);
 	base_time = seconds_read();
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 
 	/* Initialize mutex1, mutex2 with PTHREAD_PRIO_INHERIT protocol */
 	mutex_attr_init(&mutex_attr);

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
@@ -254,6 +254,7 @@ void *thread_tb(void *arg)
 
 int main(int argc, char **argv)
 {
+	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1], threadsample, threadtp, threadtl, threadtb;
@@ -263,7 +264,6 @@ int main(int argc, char **argv)
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 6);
 	base_time = seconds_read();
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 
 	/* Initialize a mutex with PTHREAD_PRIO_INHERIT protocol */
 	mutex_attr_init(&mutex_attr);

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
@@ -240,7 +240,6 @@ int main(int argc, char **argv)
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 6);
 	base_time = seconds_read();
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 
 	/* Initialize a mutex with PTHREAD_PRIO_INHERIT protocol */
 	mutex_attr_init(&mutex_attr);


### PR DESCRIPTION
Make sure to first initialize the variable before using it for
variable-length array initialization.

Signed-off-by: Ryan Zezeski <rpz@joyent.com>