### PR TITLE
open_posix_testsuite: pitest: limit number of threads

### DIFF
--- a/testcases/open_posix_testsuite/functional/threads/include/pitest.h
+++ b/testcases/open_posix_testsuite/functional/threads/include/pitest.h
@@ -12,6 +12,8 @@
 #include "test.h"
 
 #define PROTOCOL                PTHREAD_PRIO_INHERIT
+#define MIN(x, y)               (((x) < (y)) ? (x) : (y))
+#define MAX_CPU                 6
 
 static inline
 double seconds_read(void)

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
@@ -230,7 +230,7 @@ void *thread_tb(void *arg)
 
 int main(int argc, char **argv)
 {
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	cpus = MIN(sysconf(_SC_NPROCESSORS_ONLN), MAX_CPU);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1], threadsample, threadtp, threadtl, threadtb;

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
@@ -255,7 +255,7 @@ void *thread_tb2(void *arg)
 
 int main(int argc, char **argv)
 {
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	cpus = MIN(sysconf(_SC_NPROCESSORS_ONLN), MAX_CPU);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1];

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
@@ -266,7 +266,7 @@ void *thread_tb2(void *arg)
 
 int main(int argc, char **argv)
 {
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	cpus = MIN(sysconf(_SC_NPROCESSORS_ONLN), MAX_CPU);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1];

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
@@ -236,7 +236,7 @@ void *thread_tb2(void *arg)
 
 int main(int argc, char **argv)
 {
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	cpus = MIN(sysconf(_SC_NPROCESSORS_ONLN), MAX_CPU);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1];

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
@@ -254,7 +254,7 @@ void *thread_tb(void *arg)
 
 int main(int argc, char **argv)
 {
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	cpus = MIN(sysconf(_SC_NPROCESSORS_ONLN), MAX_CPU);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1], threadsample, threadtp, threadtl, threadtb;

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
@@ -229,7 +229,7 @@ void *thread_tb(void *arg)
 
 int main(int argc, char **argv)
 {
-	cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	cpus = MIN(sysconf(_SC_NPROCESSORS_ONLN), MAX_CPU);
 	pthread_mutexattr_t mutex_attr;
 	pthread_attr_t threadattr;
 	pthread_t threads[cpus - 1], threadsample, threadtp, threadtl, threadtb;


### PR DESCRIPTION
The pitest must limit the number of TF threads to 6 to avoid
referencing memory outside tp[] when the number of online CPUs is
greater than 6.

Signed-off-by: Ryan Zezeski <rpz@joyent.com>