### PR TITLE
WIP: Android support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -250,6 +250,13 @@ uClinux Users
 Specify UCLINUX=1 when calling make; -DUCLINUX=1 use is deprecated and highly
 discouraged.
 
+Android Users
+-------------
+Specify ANDROID=1 when calling make. Many tests which would otherwise work are
+currently not built because they share a directory with an incompatible test.
+
+The shell scripts expect /bin/sh to exist, so create a symlink.
+
 Variables in Makefile
 ----------------------
 

--- a/include/mk/env_post.mk
+++ b/include/mk/env_post.mk
@@ -41,6 +41,15 @@ ifeq ($(UCLINUX),1)
 CPPFLAGS			+= -D__UCLIBC__ -DUCLINUX
 endif
 
+ifeq ($(ANDROID),1)
+# There are many undeclared functions, it's best not to accidentally overlook
+# them.
+CFLAGS				+= -Werror-implicit-function-declaration
+
+LDFLAGS				+= -L$(top_builddir)/lib/android_libpthread
+LDFLAGS				+= -L$(top_builddir)/lib/android_librt
+endif
+
 MAKE_TARGETS			?= $(notdir $(patsubst %.c,%,$(wildcard $(abs_srcdir)/*.c)))
 
 MAKE_TARGETS			:= $(filter-out $(FILTER_OUT_MAKE_TARGETS),$(MAKE_TARGETS))

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -26,6 +26,12 @@ include $(top_srcdir)/include/mk/env_pre.mk
 
 CFLAGS			+= -I.
 
+ifneq ($(ANDROID),1)
+FILTER_OUT_DIRS		+= android_libpthread android_librt
+else
+FILTER_OUT_LIBSRCS	+= tlibio.c tst_path_has_mnt_flags.c
+endif
+
 LIB			:= libltp.a
 
 pc_file			:= $(DESTDIR)/$(datarootdir)/pkgconfig/ltp.pc

--- a/lib/newlib_tests/Makefile
+++ b/lib/newlib_tests/Makefile
@@ -8,4 +8,9 @@ LDLIBS			+= -lltp
 test08: CFLAGS+=-pthread
 test09: CFLAGS+=-pthread
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_MAKE_TARGETS	+= test08
+endif
+
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/lib/tst_res.c
+++ b/lib/tst_res.c
@@ -80,6 +80,10 @@ int TEST_ERRNO;
 	assert(strlen(buf) > 0);		\
 } while (0)
 
+#if defined(__ANDROID__) && !defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
+#define PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
+#endif
+
 static pthread_mutex_t tmutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 static void check_env(void);

--- a/testcases/kernel/Makefile
+++ b/testcases/kernel/Makefile
@@ -61,6 +61,11 @@ endif
 
 endif
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_DIRS		+= containers controllers device-drivers fs io ipc mem \
+				sched security timers
+endif
+
 MAKE_DEPS		:= include/linux_syscall_numbers.h
 
 include:

--- a/testcases/kernel/syscalls/Makefile
+++ b/testcases/kernel/syscalls/Makefile
@@ -33,4 +33,16 @@ ifeq ($(UCLIBC),1)
 FILTER_OUT_DIRS	+= profil
 endif
 
+ifeq ($(ANDROID), 1)
+FILTER_OUT_DIRS	+= \
+	accept4 adjtimex cma confstr fcntl fmtmsg futex getcontext getcpu \
+	getdomainname getdtablesize gethostid getgroups get_mempolicy ipc \
+	linkat kill mallopt memmap mq_notify mq_open mq_timedreceive \
+	mq_timedsend mq_unlink mmap mremap open openat profil ptrace quotactl \
+	readahead remap_file_pages rt_sigsuspend rt_sigtimedwait \
+	sched_getaffinity sched_setaffinity sendmsg setgroups setns sighold \
+	sigrelse sigsuspend sigtimedwait sigwait sigwaitinfo stime \
+	setdomainname sethostname symlinkat ulimit ustat vfork vhangup vmsplice
+endif
+
 include $(top_srcdir)/include/mk/generic_trunk_target.mk

--- a/testcases/kernel/syscalls/creat/Makefile
+++ b/testcases/kernel/syscalls/creat/Makefile
@@ -20,4 +20,8 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_MAKE_TARGETS	+= creat05
+endif
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/dup/Makefile
+++ b/testcases/kernel/syscalls/dup/Makefile
@@ -20,4 +20,8 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 
+ifeq ($(ANDROID), 1)
+FILTER_OUT_MAKE_TARGETS	+= dup06
+endif
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/dup2/Makefile
+++ b/testcases/kernel/syscalls/dup2/Makefile
@@ -20,4 +20,8 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_MAKE_TARGETS	+= dup201 dup205
+endif
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/gettid/Makefile
+++ b/testcases/kernel/syscalls/gettid/Makefile
@@ -24,4 +24,8 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 
+ifeq ($(ANDROID), 1)
+FILTER_OUT_MAKE_TARGETS	+= gettid01
+endif
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/ioctl/Makefile
+++ b/testcases/kernel/syscalls/ioctl/Makefile
@@ -22,4 +22,8 @@ include $(top_srcdir)/include/mk/testcases.mk
 
 INSTALL_TARGETS		+= test_ioctl
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_MAKE_TARGETS	+= ioctl02
+endif
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/pipe/Makefile
+++ b/testcases/kernel/syscalls/pipe/Makefile
@@ -20,4 +20,8 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_MAKE_TARGETS	+= pipe06 pipe07
+endif
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/setrlimit/Makefile
+++ b/testcases/kernel/syscalls/setrlimit/Makefile
@@ -20,4 +20,8 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_MAKE_TARGETS	+= setrlimit01
+endif
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/misc/math/Makefile
+++ b/testcases/misc/math/Makefile
@@ -22,6 +22,10 @@
 
 top_srcdir		?= ../../..
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_DIRS		:= abs float
+endif
+
 include $(top_srcdir)/include/mk/env_pre.mk
 
 include $(top_srcdir)/include/mk/generic_trunk_target.mk

--- a/testcases/network/Makefile
+++ b/testcases/network/Makefile
@@ -35,6 +35,10 @@ INSTALL_TARGETS		+= $(addprefix $(DIR)/bin.,sm med lg jmb)
 
 RM			+= -r
 
+ifeq ($(ANDROID),1)
+FILTER_OUT_DIRS		+= lib6 rpc sockets
+endif
+
 $(INSTALL_TARGETS): | generate
 
 .PHONY: generate

--- a/testcases/network/multicast/Makefile
+++ b/testcases/network/multicast/Makefile
@@ -23,4 +23,9 @@
 top_srcdir		?= ../../..
 
 include $(top_srcdir)/include/mk/env_pre.mk
+
+ifeq ($(ANDROID),1)
+FILTER_OUT_DIRS		+= mc_gethost
+endif
+
 include $(top_srcdir)/include/mk/generic_trunk_target.mk

--- a/testcases/network/stress/Makefile
+++ b/testcases/network/stress/Makefile
@@ -23,4 +23,9 @@
 top_srcdir		?= ../../..
 
 include $(top_srcdir)/include/mk/env_pre.mk
+
+ifeq ($(ANDROID), 1)
+FILTER_OUT_DIRS		+= ns-tools
+endif
+
 include $(top_srcdir)/include/mk/generic_trunk_target.mk

--- a/utils/benchmark/Makefile
+++ b/utils/benchmark/Makefile
@@ -21,4 +21,9 @@
 top_srcdir		?= ../..
 
 include $(top_srcdir)/include/mk/env_pre.mk
+
+ifeq ($(ANDROID),1)
+FILTER_OUT_DIRS		+= ebizzy-0.3
+endif
+
 include $(top_srcdir)/include/mk/generic_trunk_target.mk


### PR DESCRIPTION
This adds support for building with Android's latest NDK. It needs testing on more configurations but thought I would get comments while I do that. I've been using Ubuntu 16.04 x64 and Arch x64.

I don't particularly like the librt and libpthread stubs, but I think it's slightly better than modifying every project that links against them.

Some of the places I've added a default block size of 512 could do with being looked at, the logic in those areas looks like it could be simplified for all platforms by just checking for the definition that's about to be used rather than speculating which platforms would define it.

I can include a complete example of downloading the latest NDK, exporting a toolchain and building if you think it's useful.

When I initially started this work I tried to exclude broken tests individually, but it would have resulted in over 50 patches to review in one go. I still intend to get as much coverage as possible, but over several pull requests.