### PR TITLE
posix/munmap: Use mmap to obtain valid and safe address range

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/munmap/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/munmap/2-1.c
@@ -4,12 +4,13 @@
  * of this license, see the COPYING file at the top level of this
  * source tree.
  *
- * If there are no
- * mappings in the specified address range, then munmap() has no effect.
+ * If there are no mappings in the specified address range, then munmap() has
+ * no effect. To get a valid address range which is safe to call munmap() on
+ * we first map some arbitrary memory allowing the OS to select the address
+ * then unmap it. We then call munmap() on the same address again to perform
+ * the test.
  *
  */
-
-#define _XOPEN_SOURCE 600
 
 #include <pthread.h>
 #include <stdio.h>
@@ -28,32 +29,46 @@
 
 int main(void)
 {
-	int rc;
+	int rc, fd, map_size;
+	void *map_addr;
 
-	int page_size;
-	void *buffer = NULL, *new_addr = NULL;
-
-	page_size = sysconf(_SC_PAGE_SIZE);
-	buffer = malloc(page_size * 2);
-	if (buffer == NULL) {
-		printf("Error at malloc\n");
-		exit(PTS_UNRESOLVED);
+	map_size = sysconf(_SC_PAGESIZE);
+	fd = open("/dev/zero", O_RDWR);
+	if (fd == -1) {
+		printf("Failed to open /dev/zero: %s (%d)\n",
+		       strerror(errno),
+		       errno);
+		return PTS_UNRESOLVED;
 	}
 
-	/* Make new_addr is a multiple of page_size, while
-	 * [new_addr, new_addr + page_size] is a valid memory range
-	 */
-	new_addr = buffer + (page_size - (unsigned long)buffer % page_size);
-
-	rc = munmap(new_addr, page_size);
-	if (rc == -1) {
-		printf("Test FAILED " TNAME " Error at munmap(): %s\n",
-		       strerror(errno));
-		free(buffer);
-		exit(PTS_FAIL);
+	map_addr = mmap(NULL, map_size, PROT_NONE, MAP_PRIVATE, fd, 0);
+	if (map_addr == MAP_FAILED) {
+		printf("Failed to map memory: %s (%d)\n",
+		       strerror(errno),
+		       errno);
+		close(fd);
+		return PTS_UNRESOLVED;
 	}
 
-	free(buffer);
+	rc = munmap(map_addr, map_size);
+	if (rc != 0) {
+		printf("Failed to unmap memory: %s (%d)\n",
+		       strerror(errno),
+		       errno);
+		close(fd);
+		return PTS_UNRESOLVED;
+	}
+
+	close(fd);
+
+	rc = munmap(map_addr, map_size);
+	if (rc != 0) {
+		printf("Test FAILED " TNAME " Error at munmap(): %s (%d)\n",
+		       strerror(errno),
+		       errno);
+		return PTS_FAIL;
+	}
+
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }


### PR DESCRIPTION
I have two versions of this test, the one in this pull request changes the feature test macro so I can use MAP_ANONYMOUS the other uses `shm_open` which is more complicated and needs an extra library linking, but doesn't require changing the macros. I could also open some file which is always present, instead of using `shm_open`, but I am guessing MAP_ANONYMOUS is preferable?


commit message:
Avoid accidentally un-mapping memory used internally by malloc by creating a
new mapping and then un-mapping it twice.

Signed-off-by: Richard Palethorpe <rpalethorpe@suse.com>