### PR TITLE
fs_di wrap $PATH environment variable in quotes

### DIFF
--- a/testcases/kernel/fs/fs_di/fs_di
+++ b/testcases/kernel/fs/fs_di/fs_di
@@ -53,7 +53,7 @@ $trace_logic
 TC=${TC:=fs_di}
 TCbin=${TCbin:=`pwd`}
 TCtmp=${TCtmp:=$TMPDIR/$TC$$}
-export PATH=$PATH:$TCbin:../../../bin
+export PATH="$PATH":$TCbin:../../../bin
 export TCID=$TC
 export TST_TOTAL=1
 export TST_COUNT=1


### PR DESCRIPTION
There is an issue with if the existing $PATH environment variable contains elements with spaces for example:

echo $PATH
/user/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/foo bar;/baz