### PR TITLE
realtime: Fix failure on missing -l argument

### DIFF
--- a/testcases/realtime/run.sh
+++ b/testcases/realtime/run.sh
@@ -203,13 +203,17 @@ do
 	case "$option" in
 
 	t )
+		LOOP=1
 		if [ $ISLOOP -eq 1 ]; then
-			LOOP=1
 			tests[$index]=$LOOP
 			: $(( index += 1 ))
 		fi
 
 		tests[$index]="$OPTARG"
+		if [ $index -eq 0 ]; then
+			tests[$index + 1]=$LOOP
+		fi
+
 		: $((index += 1 ))
 		TESTCASE="$OPTARG"
 		ISLOOP=1


### PR DESCRIPTION
Executing the following command:

./testcases/realtime/run.sh -t all

gives me the following error:

./run.sh: line 87: 0 +  : syntax error: operand expected (error token
is "+  ")

The problem is the loop argument is not set when only 1 argument (-t all)\
is passed. Fixing this by making sure tests[1] is initialized to 1.

Signed-off-by: Vedang Patel <vedang.patel@intel.com>