### PR TITLE
syscalls/eventfd01: Wait for async overflow

### DIFF
--- a/testcases/kernel/syscalls/eventfd/eventfd01.c
+++ b/testcases/kernel/syscalls/eventfd/eventfd01.c
@@ -504,6 +504,7 @@ static int trigger_eventfd_overflow(int evfd, int *fd, io_context_t * ctx)
 	int ret;
 	struct iocb iocb;
 	struct iocb *iocbap[1];
+	struct io_event ioev;
 	static char buf[4 * 1024];
 
 	*ctx = 0;
@@ -534,6 +535,13 @@ static int trigger_eventfd_overflow(int evfd, int *fd, io_context_t * ctx)
 	if (ret < 0) {
 		errno = -ret;
 		tst_resm(TINFO | TERRNO, "error submitting iocb");
+		goto err_close_file;
+	}
+
+	ret = io_getevents(*ctx, 1, 1, &ioev, NULL);
+	if (ret < 0) {
+		errno = -ret;
+		tst_resm(TINFO | TERRNO, "error waiting for event");
 		goto err_close_file;
 	}
 


### PR DESCRIPTION
Since the eventfd overflow is triggered via AIO, a call to io_getevents should be used to ensure that the operation has concluded before other portions of the test occur.  This prevents cases where the test encounters an undesirable result due to a delay in AIO completion.