### PR TITLE
testcases: fix file path to control access to cron

### DIFF
--- a/testcases/commands/cron/cron_allow01
+++ b/testcases/commands/cron/cron_allow01
@@ -31,12 +31,7 @@ iam=`whoami`
 tvar=${MACHTYPE%-*}
 tvar=${tvar#*-}
 
-if [ "$tvar" = "redhat" -o "$tvar" = "redhat-linux" ]
-then
 CRON_ALLOW="/etc/cron.allow"
-else
-CRON_ALLOW="/var/spool/cron/allow"
-fi
 
 TEST_USER1="ca_user1"
 TEST_USER1_HOME="/home/$TEST_USER1"


### PR DESCRIPTION
Now, crontab uses /etc/cron.allow to allow access on most of the distributions as well as redhat.

Signed-off-by: Myungho Jung <mhjungk@gmail.com>