### PR TITLE
testcases: fix insecure permission error in logrotate test

### DIFF
--- a/testcases/commands/logrotate/logrotate_tests.sh
+++ b/testcases/commands/logrotate/logrotate_tests.sh
@@ -163,6 +163,7 @@ test01()
 	compress
 
 	/var/log/tst_logfile {
+		su root syslog
 		rotate 5
 		weekly
 	}


### PR DESCRIPTION
/var/log/ is owned by syslog which causes insecure permission error
while running logrotate. It can be resolved by su command.

Signed-off-by: Myungho Jung <mhjungk@gmail.com>