### PR TITLE
You cannot assume the thread has read the arg before you start creating the next thread.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,15 @@ fi
 
 AC_CONFIG_SUBDIRS([utils/ffsb-6.0-rc2])
 
+AC_ARG_WITH([dmx],
+  [AC_HELP_STRING([--with-dmx],
+    [Have Diablo DMX Memory (default=no)])],
+  [with_dmx=yes],
+)
+if test "x$with_dmx" = xyes; then
+    AC_DEFINE(WITH_DMX, 1, [Define to 1 if you have DMX Memory])
+fi
+
 # END testsuites knobs
 LTP_CHECK_FORTIFY_SOURCE
 LTP_CHECK_CC_WARN_OLDSTYLE

--- a/include/tst_clone.h
+++ b/include/tst_clone.h
@@ -36,4 +36,19 @@ int ltp_clone_quick(unsigned long clone_flags, int (*fn)(void *arg),
 
 #define clone(...) (use_the_ltp_clone_functions__do_not_use_clone)
 
+#ifdef WITH_DMX
+#include <sys/mman.h>
+
+#ifdef MAP_STACK
+static inline void *stack_malloc(size_t size)
+{
+	void *stack = mmap(NULL, size, PROT_READ | PROT_WRITE,
+					   MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+	return stack == MAP_FAILED ? NULL : stack;
+}
+#endif
+#else
+#define stack_malloc malloc
+#endif
+
 #endif	/* TST_CLONE_H__ */

--- a/lib/cloner.c
+++ b/lib/cloner.c
@@ -129,7 +129,7 @@ ltp_clone_malloc(unsigned long clone_flags, int (*fn) (void *arg), void *arg,
 	int ret;
 	int saved_errno;
 
-	stack = malloc(stack_size);
+	stack = stack_malloc(stack_size);
 	if (stack == NULL)
 		return -1;
 

--- a/testcases/kernel/containers/pidns/pidns13.c
+++ b/testcases/kernel/containers/pidns/pidns13.c
@@ -176,7 +176,7 @@ static void setup(void)
 int main(int argc, char *argv[])
 {
 	int status;
-	int *cinit_no = malloc(sizeof(int));
+	int *cinit_no = malloc(sizeof(int) * 2);
 	pid_t cpid1, cpid2;
 
 	setup();
@@ -192,12 +192,12 @@ int main(int argc, char *argv[])
 	}
 
 	/* Create container 1 */
-	*cinit_no = 1;
-	cpid1 = ltp_clone_quick(CLONE_NEWPID | SIGCHLD, child_fn, cinit_no);
+	cinit_no[0] = 1;
+	cpid1 = ltp_clone_quick(CLONE_NEWPID | SIGCHLD, child_fn, &cinit_no[0]);
 
 	/* Create container 2 */
-	*cinit_no = 2;
-	cpid2 = ltp_clone_quick(CLONE_NEWPID | SIGCHLD, child_fn, cinit_no);
+	cinit_no[1] = 2;
+	cpid2 = ltp_clone_quick(CLONE_NEWPID | SIGCHLD, child_fn, &cinit_no[1]);
 	if (cpid1 < 0 || cpid2 < 0) {
 		tst_resm(TBROK, "parent: clone() failed.");
 	}

--- a/testcases/kernel/syscalls/clone/clone01.c
+++ b/testcases/kernel/syscalls/clone/clone01.c
@@ -48,7 +48,7 @@ int main(int ac, char **av)
 
 	setup();
 
-	child_stack = malloc(CHILD_STACK_SIZE);
+	child_stack = stack_malloc(CHILD_STACK_SIZE);
 	if (child_stack == NULL)
 		tst_brkm(TBROK, cleanup, "Cannot allocate stack for child");
 

--- a/testcases/kernel/syscalls/clone/clone02.c
+++ b/testcases/kernel/syscalls/clone/clone02.c
@@ -121,7 +121,7 @@ int main(int ac, char **av)
 
 	setup();
 
-	child_stack = malloc(CHILD_STACK_SIZE);
+	child_stack = stack_malloc(CHILD_STACK_SIZE);
 	if (child_stack == NULL)
 		tst_brkm(TBROK, cleanup, "Cannot allocate stack for child");
 

--- a/testcases/kernel/syscalls/clone/clone03.c
+++ b/testcases/kernel/syscalls/clone/clone03.c
@@ -66,7 +66,7 @@ int main(int ac, char **av)
 	setup();
 
 	/* Allocate stack for child */
-	child_stack = malloc(CHILD_STACK_SIZE);
+	child_stack = stack_malloc(CHILD_STACK_SIZE);
 	if (child_stack == NULL)
 		tst_brkm(TBROK, cleanup, "Cannot allocate stack for child");
 

--- a/testcases/kernel/syscalls/clone/clone04.c
+++ b/testcases/kernel/syscalls/clone/clone04.c
@@ -99,7 +99,7 @@ static void setup(void)
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 	TEST_PAUSE;
 
-	child_stack = malloc(CHILD_STACK_SIZE);
+	child_stack = stack_malloc(CHILD_STACK_SIZE);
 }
 
 static void cleanup(void)

--- a/testcases/kernel/syscalls/clone/clone05.c
+++ b/testcases/kernel/syscalls/clone/clone05.c
@@ -49,7 +49,7 @@ int main(int ac, char **av)
 
 	setup();
 
-	child_stack = malloc(CHILD_STACK_SIZE);
+	child_stack = stack_malloc(CHILD_STACK_SIZE);
 	if (child_stack == NULL)
 		tst_brkm(TBROK, cleanup, "Cannot allocate stack for child");
 

--- a/testcases/kernel/syscalls/clone/clone06.c
+++ b/testcases/kernel/syscalls/clone/clone06.c
@@ -55,7 +55,7 @@ int main(int ac, char **av)
 
 	setup();
 
-	child_stack = malloc(CHILD_STACK_SIZE);
+	child_stack = stack_malloc(CHILD_STACK_SIZE);
 	if (child_stack == NULL)
 		tst_brkm(TBROK, cleanup, "Cannot allocate stack for child");
 

--- a/testcases/kernel/syscalls/clone/clone07.c
+++ b/testcases/kernel/syscalls/clone/clone07.c
@@ -56,7 +56,7 @@ int main(int ac, char **av)
 
 	for (lc = 0; TEST_LOOPING(lc); lc++) {
 		tst_count = 0;
-		child_stack = malloc(CHILD_STACK_SIZE);
+		child_stack = stack_malloc(CHILD_STACK_SIZE);
 		if (child_stack == NULL)
 			tst_brkm(TBROK, NULL,
 				 "Cannot allocate stack for child");


### PR DESCRIPTION
We where failing this test only because both threads where seeing 2 as the argument.