### PR TITLE
containers/netns: remove local keyword for dash shell

### DIFF
--- a/testcases/kernel/containers/netns/netns_helper.sh
+++ b/testcases/kernel/containers/netns/netns_helper.sh
@@ -63,8 +63,8 @@ IFCONF_IN6_ARG=""
 
 tst_check_iproute()
 {
-	local cur_ipver=`ip -V`
-	local spe_ipver=$1
+	local cur_ipver="$(ip -V)"
+	local spe_ipver="$1"
 
 	cur_ipver=${cur_ipver##*s}
 


### PR DESCRIPTION
When running netns tests with dash shell, the error message
'netns_comm.sh: 66: local: utility,: bad variable name' observed, and it
causes test failures. Refer to the below bug for more information about
the error with dash.

https://bugs.launchpad.net/ubuntu/+source/dash/+bug/139097

netns tests run with portable shell '/bin/sh'. Although local keyword is
supported by most of POSIX-compliant shells, it is not defined by POSIX.
And both 'cur_ipver' and 'spe_ipver' variables only used in
tst_check_iproute() in 'containers/netns/netns_helper.sh', scoping them
inside the function isn't needed. Removing the local keyword fixes the
above error and make the tests more portable.

Putting variable value in double quotes or splitting variable
declaration and assignment also works, but they are probably less
portable.

Signed-off-by: Chase Qi <chase.qi@linaro.org>