### PR TITLE
[PATCH v4] testcases: fix file path to control access to cron

### DIFF
--- a/testcases/commands/cron/cron_allow01
+++ b/testcases/commands/cron/cron_allow01
@@ -26,17 +26,7 @@
 
 echo "This script contains bashism that needs to be fixed!"
 
-iam=`whoami`
-
-tvar=${MACHTYPE%-*}
-tvar=${tvar#*-}
-
-if [ "$tvar" = "redhat" -o "$tvar" = "redhat-linux" ]
-then
-CRON_ALLOW="/etc/cron.allow"
-else
-CRON_ALLOW="/var/spool/cron/allow"
-fi
+. cron_common.sh
 
 TEST_USER1="ca_user1"
 TEST_USER1_HOME="/home/$TEST_USER1"

--- a/testcases/commands/cron/cron_common.sh
+++ b/testcases/commands/cron/cron_common.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+iam=`whoami`
+
+tvar=${MACHTYPE%-*}
+tvar=${tvar#*-}
+
+setup_path() {
+	# Support paths used by older distributions of RHEL or SLES.
+	export CRON_DENY="$(man crontab 2>/dev/null | grep -m 1 -o '/[\/a-z.]*deny$' || echo "/etc/cron.deny")"
+	export CRON_ALLOW="$(man crontab 2>/dev/null | grep -m 1 -o '/[\/a-z.]*allow$' || echo "/etc/cron.allow")"
+}
+
+setup_path
+

--- a/testcases/commands/cron/cron_deny01
+++ b/testcases/commands/cron/cron_deny01
@@ -26,19 +26,7 @@
 
 echo "This script contains bashism that needs to be fixed!"
 
-iam=`whoami`
-
-tvar=${MACHTYPE%-*}
-tvar=${tvar#*-}
-
-if [ "$tvar" = "redhat" -o "$tvar" = "redhat-linux" ]
-then
-CRON_DENY="/etc/cron.deny"
-CRON_ALLOW="/etc/cron.allow"
-else
-CRON_DENY="/var/spool/cron/deny"
-CRON_ALLOW="/var/spool/cron/allow"
-fi
+. cron_common.sh
 
 TEST_USER1="cd_user1"
 TEST_USER1_HOME="/home/$TEST_USER1"

--- a/testcases/commands/cron/cron_neg_tests.sh
+++ b/testcases/commands/cron/cron_neg_tests.sh
@@ -9,7 +9,7 @@
 #    12/03/04  Marty Ridgeway Pull RHEl4 tests out from script
 ########################################################
 
-iam=`whoami`
+. cron_common.sh
 
 if [ $iam = "root" ]; then
 	if [ $# -lt 1 ] ; then

--- a/testcases/commands/cron/cron_pos_tests.sh
+++ b/testcases/commands/cron/cron_pos_tests.sh
@@ -2,18 +2,7 @@
 
 # Positive tests for cron, that means these tests have to pass
 
-iam=`whoami`
-
-tvar=${MACHTYPE%-*}
-tvar=${tvar#*-}
-
-if [ "$tvar" = "redhat" -o "$tvar" = "redhat-linux" ]
-then
-	CRON_ALLOW="/etc/cron.allow"
-else
-	CRON_ALLOW="/var/spool/cron/allow"
-fi
-
+. cron_common.sh
 
 if [ $iam = "root" ]; then
 	if [ $# -lt 1 ] ; then


### PR DESCRIPTION
crontab uses /etc/cron.{allow,deny} to control access on most distributions, as well as RHEL. To maintain backwards compatibility with older still supported distributions, the test setup will search the man page for the correct paths (e.g. /var/spool/cron/allow). If the man page is not available (e.g. on an embedded device), it will default to the /etc paths. This method supports vixie-cron, cronie, etc...

The repeating code has been moved into a common shell script library to simplify maintenance.

Reported-by: Myungho Jung <mhjungk@gmail.com>
Signed-off-by: Lucas Magasweran <lucas.magasweran@ieee.org>
Tested-by: Dan Rue <drue@therub.org>

---

Changes in v2: 
* This based on the feedback in https://github.com/linux-test-project/ltp/pull/149 . I could not figure out a reliable way to detect the path based on the distribution since each distribution uses a different cron (e.g. cronie, vixie cron, etc.) and this varies across distro releases. I even tried `strace` to see which file `crontab -l` opened. This was reliable but may break in the future.

Changes in v3:
* Require a leading slash to match absolute paths in RHEL7.4.
* Require trailing whitespace to the end of line to not match multiple occurrences with cron 3.0pl1-128ubuntu2 man page on Ubuntu 16.04.

Changes in v4:
* Simplify pattern matching to expect the end of line after the path in the FILES section.