### PR TITLE
Cpuctl indentation

### DIFF
--- a/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
@@ -66,7 +66,7 @@
 #define TIME_INTERVAL	30	/* Time interval in seconds */
 #define NUM_INTERVALS	3	/* How many iterations of TIME_INTERVAL */
 #define NUM_SETS	4	/* How many share values (with same ratio) */
-#define MULTIPLIER   	10	/* decides the rate at which share value gets multiplied */
+#define MULTIPLIER	10	/* decides the rate at which share value gets multiplied */
 #define GRANULARITY    5	/* % value by which shares of a group changes */
 char *TCID = "cpuctl_test01";
 int TST_TOTAL = 1;

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
@@ -14,7 +14,8 @@
 /*                                                                            */
 /* You should have received a copy of the GNU General Public License          */
 /* along with this program;  if not, write to the Free Software               */
-/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA    */
+/* Foundation, Inc.,							      */
+/* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA		      */
 /*                                                                            */
 /******************************************************************************/
 


### PR DESCRIPTION
Keep the initial license comment to 80 columns. 
Fix the space/tab mix.

Signed-off-by: Marcin Wolcendorf <mwolcendorf@suse.com>