### PR TITLE
Controllers cpuctl code cleanup

### DIFF
--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
@@ -69,7 +69,7 @@
 #define NUM_SETS	4	/* How many share values (with same ratio) */
 #define MULTIPLIER   	10	/* Rate at which share value gets multiplied */
 
-char *TCID = "cpu_controller_tests";
+char *TCID = "cpuctl_def_task01";
 int TST_TOTAL = 1;
 pid_t scriptpid;
 char path[FILENAME_MAX] = "/dev/cpuctl";

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 	time_t current_time, prev_time, delta_time;
 	unsigned long int myshares = 2, baseshares = 1000;
 	unsigned int fmyshares, num_tasks;
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	num_cpus = 0;
 	test_num = 0;
@@ -111,7 +111,8 @@ int main(int argc, char *argv[])
 	sigemptyset(&newaction.sa_mask);
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
-	sigaction(SIGALRM, &newaction, &oldaction);
+	if (sigaction(SIGALRM, &newaction, NULL) != 0)
+		errx(1, "cpuctl_def_task01 sigaction");
 
 	/* Check if all parameters passed are correct */
 	if ((argc < 5) || ((my_group_num = atoi(argv[1])) <= 0) ||

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
@@ -73,6 +73,8 @@ char *TCID = "cpu_controller_tests";
 int TST_TOTAL = 1;
 pid_t scriptpid;
 char path[FILENAME_MAX] = "/dev/cpuctl";
+unsigned int total_shares;
+unsigned int *shares_pointer;
 
 extern void cleanup(void)
 {

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task01.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
 	if (sigaction(SIGALRM, &newaction, NULL) != 0)
-		errx(1, "cpuctl_def_task01 sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	/* Check if all parameters passed are correct */
 	if ((argc < 5) || ((my_group_num = atoi(argv[1])) <= 0) ||

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
@@ -64,7 +64,7 @@
 #define TIME_INTERVAL	30	/* Time interval in seconds */
 #define NUM_INTERVALS	3	/* How many iterations of TIME_INTERVAL */
 
-char *TCID = "cpu_controller_test04";
+char *TCID = "cpuctl_def_task02";
 int TST_TOTAL = 1;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
@@ -68,6 +68,8 @@ char *TCID = "cpu_controller_test04";
 int TST_TOTAL = 1;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";
+unsigned int total_shares;
+unsigned int *shares_pointer;
 
 extern void cleanup(void)
 {

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
@@ -77,7 +77,7 @@ extern void cleanup(void)
 
 volatile int timer_expired = 0;
 
-int main(int argc, char *argv[])
+int main(void)
 {
 
 	int test_num;

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
@@ -116,7 +116,7 @@ int main(void)
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
 	if (sigaction(SIGALRM, &newaction, NULL) != 0)
-		errx(1, "cpuctl_def_task02 sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task02.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	struct rusage cpu_usage;
 	time_t current_time, prev_time, delta_time;
 	unsigned int fmyshares, num_tasks;
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	mygroup_num = -1;
 	num_cpus = 0;
@@ -113,7 +113,8 @@ int main(int argc, char *argv[])
 	sigemptyset(&newaction.sa_mask);
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
-	sigaction(SIGALRM, &newaction, &oldaction);
+	if (sigaction(SIGALRM, &newaction, NULL) != 0)
+		errx(1, "cpuctl_def_task02 sigaction");
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
 	if (sigaction(SIGALRM, &newaction, NULL) != 0)
-		errx(1, "cpuctl_def_task03 sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
 	struct rusage cpu_usage;
 	time_t current_time, prev_time, delta_time;
 	unsigned int fmyshares, num_tasks;
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	mygroup_num = -1;
 	num_cpus = 0;
@@ -109,7 +109,8 @@ int main(int argc, char *argv[])
 	sigemptyset(&newaction.sa_mask);
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
-	sigaction(SIGALRM, &newaction, &oldaction);
+	if (sigaction(SIGALRM, &newaction, NULL) != 0)
+		errx(1, "cpuctl_def_task03 sigaction");
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
@@ -65,7 +65,7 @@
 #define TIME_INTERVAL	30	/* Time interval in seconds */
 #define NUM_INTERVALS	2	/* How many iterations of TIME_INTERVAL */
 
-char *TCID = "cpu_controller_test06";
+char *TCID = "cpuctl_def_task03";
 int TST_TOTAL = 3;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task03.c
@@ -69,7 +69,10 @@ char *TCID = "cpu_controller_test06";
 int TST_TOTAL = 3;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";
-extern void cleanup(void)
+unsigned int total_shares;
+unsigned int *shares_pointer;
+
+void cleanup(void)
 {
 	kill(scriptpid, SIGUSR1);	/* Inform the shell to do cleanup */
 	/* Report exit status */

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
@@ -77,7 +77,7 @@ extern void cleanup()
 
 volatile int timer_expired = 0;
 
-int main(int argc, char *argv[])
+int main(void)
 {
 
 	int test_num;

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
@@ -116,7 +116,7 @@ int main(void)
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
 	if (sigaction(SIGALRM, &newaction, NULL) != 0)
-		errx(1, "cpuctl_def_task04 sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
@@ -65,7 +65,7 @@
 #define TIME_INTERVAL	100	/* Time interval in seconds */
 #define NUM_INTERVALS	2	/* How many iterations of TIME_INTERVAL */
 
-char *TCID = "cpu_controller_test06";
+char *TCID = "cpuctl_def_task04";
 int TST_TOTAL = 2;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 	time_t current_time, prev_time, delta_time;
 	unsigned int fmyshares, num_tasks;
 	unsigned int mygroup_shares;
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	mygroup_num = -1;
 	num_cpus = 0;
@@ -112,7 +112,8 @@ int main(int argc, char *argv[])
 	sigemptyset(&newaction.sa_mask);
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
-	sigaction(SIGALRM, &newaction, &oldaction);
+	if (sigaction(SIGALRM, &newaction, NULL) != 0)
+		errx(1, "cpuctl_def_task04 sigaction");
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_def_task04.c
@@ -69,6 +69,9 @@ char *TCID = "cpu_controller_test06";
 int TST_TOTAL = 2;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";
+unsigned int total_shares;
+unsigned int *shares_pointer;
+
 extern void cleanup()
 {
 	kill(scriptpid, SIGUSR1);	/* Inform the shell to do cleanup */

--- a/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
@@ -50,11 +50,12 @@
 #include <unistd.h>
 
 #include "../libcontrollers/libcontrollers.h"
+#include "test.h"		/* LTP harness APIs */
 
 char *TCID = "cpu_controller_latency_tests";
 int TST_TOTAL = 2;
 
-void sighandler(int i)
+void sighandler(int i LTP_ATTRIBUTE_UNUSED)
 {
 	exit(0);
 }

--- a/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
@@ -64,13 +64,14 @@ int main(int argc, char *argv[])
 	char mytaskfile[FILENAME_MAX];
 	int test_num;
 
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	/* TODO (garrcoop): add error handling. */
 	sigemptyset(&newaction.sa_mask);
 	sigaddset(&newaction.sa_mask, SIGUSR1);
 	newaction.sa_handler = &sighandler;
-	sigaction(SIGUSR1, &newaction, &oldaction);
+	if (sigaction(SIGUSR1, &newaction, NULL) != 0)
+		errx(1, "cpuctl_latency_test sigaction");
 
 	if (argc < 2 || argc > 3) {
 		errx(EINVAL, "TBROK\t Invalid #args received from script"

--- a/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
@@ -52,7 +52,7 @@
 #include "../libcontrollers/libcontrollers.h"
 #include "test.h"		/* LTP harness APIs */
 
-char *TCID = "cpu_controller_latency_tests";
+char *TCID = "cpu_controller_latency_test";
 int TST_TOTAL = 2;
 
 void sighandler(int i LTP_ATTRIBUTE_UNUSED)

--- a/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_latency_test.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 	sigaddset(&newaction.sa_mask, SIGUSR1);
 	newaction.sa_handler = &sighandler;
 	if (sigaction(SIGUSR1, &newaction, NULL) != 0)
-		errx(1, "cpuctl_latency_test sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	if (argc < 2 || argc > 3) {
 		errx(EINVAL, "TBROK\t Invalid #args received from script"

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
@@ -86,7 +86,6 @@ volatile int timer_expired = 0;
 
 int main(int argc, char *argv[])
 {
-
 	int num_cpus;
 	int test_num;
 	int len;		/* Total time = TIME_INTERVAL *num_cpus in the machine */

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test01.c
@@ -91,8 +91,8 @@ int main(int argc, char *argv[])
 	pid_t pid;
 	gid_t my_group_num;	/* A number attached with a group */
 	int fd;			/* A descriptor to open a fifo for synchronized start */
-	int first_counter = 0;	/* To take n number of readings */
-	int second_counter = 0;	/* To track number of times the base value of shares has been changed */
+	int interval_cnt = 0;	/* To take n number of readings */
+	int test_set_cnt = 0;	/* To track number of times the base value of shares has been changed */
 	double total_cpu_time,	/* Accumulated cpu time */
 	 delta_cpu_time,	/* Time the task could run on cpu(s) (in an interval) */
 	 prev_cpu_time = 0;
@@ -209,12 +209,12 @@ int main(int argc, char *argv[])
 		fprintf(stdout, "task-%d:CPU TIME{calc:-%6.2f(s)i.e. %6.2f(%%) exp:-%6.2f(%%)}\
 with %lu(shares) in %lu (s) INTERVAL\n", my_group_num, delta_cpu_time, mytime,
 			exp_cpu_time, myshares, delta_time);
-		first_counter++;
+		interval_cnt++;
 
-		if (first_counter >= NUM_INTERVALS) {	/* Take n sets of readings for each shares value */
-			first_counter = 0;
-			second_counter++;
-			if (second_counter >= NUM_SETS)
+		if (interval_cnt >= NUM_INTERVALS) {	/* Take n sets of readings for each shares value */
+			interval_cnt = 0;
+			test_set_cnt++;
+			if (test_set_cnt >= NUM_SETS)
 				exit(0);	/* This task is done with its job */
 
 			/* Change share values depending on the test_num */

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
@@ -69,8 +69,10 @@ char *TCID = "cpuctl_test02";
 int TST_TOTAL = 1;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";
+unsigned int total_shares;
+unsigned int *shares_pointer;
 
-extern void cleanup()
+void cleanup(void)
 {
 	kill(scriptpid, SIGUSR1);	/* Inform the shell to do cleanup */
 	tst_exit();		/* Report exit status */
@@ -276,7 +278,7 @@ with %u(shares) in %lu (s) INTERVAL\n", mygroup_num, task_num, delta_cpu_time,
 	}			/* end while */
 }				/* end main */
 
-int migrate_task()
+int migrate_task(void)
 {
 	char target[32] = "/dev/cpuctl/group_2/tasks";	/* Hard coding..Will try dynamic */
 	pid_t pid = getpid();

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
@@ -79,7 +79,7 @@ extern void cleanup()
 int migrate_task();
 volatile int timer_expired = 0;
 
-int main(int argc, char *argv[])
+int main(int argc LTP_ATTRIBUTE_UNUSED, char *argv[] LTP_ATTRIBUTE_UNUSED)
 {
 
 	int test_num;

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
@@ -118,7 +118,7 @@ int main(int argc LTP_ATTRIBUTE_UNUSED, char *argv[] LTP_ATTRIBUTE_UNUSED)
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
 	if (sigaction(SIGALRM, &newaction, NULL) != 0)
-		errx(1, "cpuctl_test02 sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test02.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 	struct rusage cpu_usage;
 	time_t current_time, prev_time, delta_time;
 	unsigned int fmyshares, num_tasks;	/* f-> from file. num_tasks is tasks in this group */
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	mygroup_num = -1;
 	num_cpus = 0;
@@ -115,7 +115,8 @@ int main(int argc, char *argv[])
 	sigemptyset(&newaction.sa_mask);
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
-	sigaction(SIGALRM, &newaction, &oldaction);
+	if (sigaction(SIGALRM, &newaction, NULL) != 0)
+		errx(1, "cpuctl_test02 sigaction");
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test03.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test03.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
 	if (sigaction(SIGALRM, &newaction, NULL) != 0)
-		errx(1, "cpuctl_test03 sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test03.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test03.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 	struct rusage cpu_usage;
 	time_t current_time, prev_time, delta_time;
 	unsigned int fmyshares, num_tasks;	/* f-> from file. num_tasks is tasks in this group */
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	mygroup_num = -1;
 	num_cpus = 0;
@@ -111,7 +111,8 @@ int main(int argc, char *argv[])
 	sigemptyset(&newaction.sa_mask);
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
-	sigaction(SIGALRM, &newaction, &oldaction);
+	if (sigaction(SIGALRM, &newaction, NULL) != 0)
+		errx(1, "cpuctl_test03 sigaction");
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test03.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test03.c
@@ -69,6 +69,9 @@ char *TCID = "cpuctl_test03";
 int TST_TOTAL = 3;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";
+unsigned int total_shares;
+unsigned int *shares_pointer;
+
 extern void cleanup(void)
 {
 	kill(scriptpid, SIGUSR1);	/* Inform the shell to do cleanup */

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test04.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
 	if (sigaction(SIGALRM, &newaction, NULL) != 0)
-		errx(1, "cpuctl_test04 sigaction");
+		errx(1, "%s sigaction", TCID);
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test04.c
@@ -69,6 +69,8 @@ char *TCID = "cpuctl_test04";
 int TST_TOTAL = 2;
 pid_t scriptpid;
 char path[] = "/dev/cpuctl";
+unsigned int total_shares;
+unsigned int *shares_pointer;
 
 extern void cleanup()
 {

--- a/testcases/kernel/controllers/cpuctl/cpuctl_test04.c
+++ b/testcases/kernel/controllers/cpuctl/cpuctl_test04.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 	unsigned long int mygroup_shares;
 	time_t current_time, prev_time, delta_time;
 	unsigned int fmyshares, num_tasks;	/* f-> from file. num_tasks is tasks in this group */
-	struct sigaction newaction, oldaction;
+	struct sigaction newaction;
 
 	mygroup_num = -1;
 	num_cpus = 0;
@@ -112,7 +112,8 @@ int main(int argc, char *argv[])
 	sigemptyset(&newaction.sa_mask);
 	newaction.sa_handler = signal_handler_alarm;
 	newaction.sa_flags = 0;
-	sigaction(SIGALRM, &newaction, &oldaction);
+	if (sigaction(SIGALRM, &newaction, NULL) != 0)
+		errx(1, "cpuctl_test04 sigaction");
 
 	/* Collect the parameters passed by the script */
 	group_num_p = getenv("GROUP_NUM");

--- a/testcases/kernel/controllers/libcontrollers/libcontrollers.c
+++ b/testcases/kernel/controllers/libcontrollers/libcontrollers.c
@@ -34,6 +34,31 @@
 /******************************************************************************/
 
 #include "libcontrollers.h"
+#include "test.h"
+
+
+volatile int timer_expired;
+int FLAG; /* FIXME(mw) - what is the purpose of this variable being global? */
+#ifdef PATH_MAX
+char fullpath[PATH_MAX];
+#else
+char fullpath[1024]; /* Guess */
+#endif
+int retval;
+struct dirent	*dir_pointer;
+char target[LINE_MAX];
+
+/*
+ * Function: error_function()
+ * Prints error message and returns -1
+ */
+
+static void error_function(char *msg1, char *msg2)
+{
+	fprintf(stdout, "ERROR: %s ", msg1);
+	fprintf(stdout, "%s\n", msg2);
+}
+
 
 /*
  * Function: scan_shares_file()
@@ -151,17 +176,6 @@ int read_file(char *filepath, int action, unsigned int *value)
 		return -1;
 	}
 	return 0;
-}
-
-/*
- * Function: error_function()
- * Prints error message and returns -1
- */
-
-static inline void error_function(char *msg1, char *msg2)
-{
-	fprintf(stdout, "ERROR: %s ", msg1);
-	fprintf(stdout, "%s\n", msg2);
 }
 
 /* Function: read_shares_file()

--- a/testcases/kernel/controllers/libcontrollers/libcontrollers.c
+++ b/testcases/kernel/controllers/libcontrollers/libcontrollers.c
@@ -207,7 +207,7 @@ int write_to_file(char *file, const char *mode, unsigned int value)
  * signal handler for the new action
  */
 
-void signal_handler_alarm(int signal)
+void signal_handler_alarm(int signal LTP_ATTRIBUTE_UNUSED)
 {
 	timer_expired = 1;
 }

--- a/testcases/kernel/controllers/libcontrollers/libcontrollers.h
+++ b/testcases/kernel/controllers/libcontrollers/libcontrollers.h
@@ -14,7 +14,8 @@
 /*                                                                            */
 /* You should have received a copy of the GNU General Public License          */
 /* along with this program;  if not, write to the Free Software               */
-/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA    */
+/* Foundation, Inc.,							      */
+/* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA		      */
 /*                                                                            */
 /******************************************************************************/
 
@@ -42,35 +43,20 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#ifdef PATH_MAX
-char fullpath[PATH_MAX];
-#else
-char fullpath[1024]; /* Guess */
-#endif
+extern char fullpath[];
 
-int FLAG;
-volatile int timer_expired;
+extern int FLAG;
+extern volatile int timer_expired;
 
-int retval;
+extern int retval;
+extern char target[];
 
-unsigned int num_line;//??
-
-unsigned int current_shares;
-
-unsigned int total_shares;
-
-unsigned int *shares_pointer;//??
-
-char target[LINE_MAX];
-
-struct dirent 	*dir_pointer;
+extern struct dirent	*dir_pointer;
 
 enum{
 	GET_SHARES	=1,
 	GET_TASKS
 };
-
-static inline void error_function(char *msg1, char *msg2);
 
 int read_shares_file(char *filepath);
 


### PR DESCRIPTION
Clean the code.

Move global variables' definitions to the files that use them, 
Change global variable definitions to declarations in header files, make them extern
Explicitly declare unused function parameters,
Remove static function declarations from headers,
Add some error processing,
Change variable names to be more meaningful


Signed-off-by: Marcin Wolcendorf <mwolcendorf@suse.com>