### PR TITLE
commands/mkfs: fix bashism in ntfs size computation

### DIFF
--- a/testcases/commands/mkfs/mkfs01.sh
+++ b/testcases/commands/mkfs/mkfs01.sh
@@ -95,7 +95,7 @@ mkfs_verify_size()
 	# 1k-block size should be devided by this argument for ntfs verification.
 	if [ "$1" = "ntfs" ]; then
 		local rate=1024/512
-		if [ $blocknum -lt "$(($2/rate*9/10))" ]; then
+		if [ $blocknum -lt "$(($2/$rate*9/10))" ]; then
 			return 1
 		fi
 	else


### PR DESCRIPTION
The Dash shell doesn't handle the division in the substitution. The test can either be changed to use Bash or the division can be done before the substitution (e.g. `local rate=2`). Or, adding the `$` seems to work and it is the fewest character change.

Signed-off-by: Lucas Magasweran <lucas.magasweran@ieee.org>