### PR TITLE
Explain memcg_stress test

### DIFF
--- a/testcases/kernel/controllers/memcg/stress/memcg_process_stress.c
+++ b/testcases/kernel/controllers/memcg/stress/memcg_process_stress.c
@@ -20,6 +20,13 @@
 /*                                                                            */
 /******************************************************************************/
 
+/*
+ * This test is supposed to stress the memory controller. In it's run, it
+ * allocates page mapping enough to map the memsize, and then continues to map
+ * the (whole) memory. It does that each time it receives a SIGUSR1, without
+ * cleaning any of already allocated memory. This is by design
+ */
+
 #include <sys/mman.h>
 #include <err.h>
 #include <math.h>


### PR DESCRIPTION
Add a general comment to the memcg stress test explaining a bit why it does
not clean-up the memory.


Signed-off-by: Marcin Wolcendorf  <mwolcendorf@suse.com>
