### PR TITLE
ltp: fix PATH_MAX undeclared when building with musl

### DIFF
--- a/include/tst_test.h
+++ b/include/tst_test.h
@@ -23,6 +23,9 @@
 #endif /* __TEST_H__ */
 
 #include <unistd.h>
+#ifndef __GLIBC__
+#include <limits.h>
+#endif
 
 #include "tst_common.h"
 #include "tst_res_flags.h"


### PR DESCRIPTION
fix PATH_MAX undeclared when building with musl.

Signed-off-by: Dengke Du <dengke.du@windriver.com>