### PR TITLE
Dengke/fix msgbuf redefinition build with musl

### DIFF
--- a/include/old/test.h
+++ b/include/old/test.h
@@ -44,6 +44,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#ifndef __GLIBC__
+#include <bits/reg.h>
+#endif
 
 #include "usctest.h"
 

--- a/testcases/kernel/syscalls/ipc/msgrcv/msgrcv08.c
+++ b/testcases/kernel/syscalls/ipc/msgrcv/msgrcv08.c
@@ -47,11 +47,13 @@ const char *TCID = "msgrcv08";
 const int TST_TOTAL = 1;
 
 #if __WORDSIZE == 32
-
+#ifdef __GLIBC__
 struct msgbuf {
 	long mtype;     /* message type, must be > 0 */
 	char mtext[16]; /* message data */
 };
+#else
+#endif
 
 static void msr(int msqid)
 {


### PR DESCRIPTION
1. fix __WORDSIZE undeclared when building with musl
2. fix redefinition of 'struct msgbuf' when building with musl