### PR TITLE
fix PATH_MAX undeclared when building with musl

### DIFF
--- a/include/tst_test.h
+++ b/include/tst_test.h
@@ -23,6 +23,7 @@
 #endif /* __TEST_H__ */
 
 #include <unistd.h>
+#include <limits.h>
 
 #include "tst_common.h"
 #include "tst_res_flags.h"


### PR DESCRIPTION
fix PATH_MAX undeclared when building with musl.

Signed-off-by: Dengke Du <dengke.du@windriver.com>