### PR TITLE
fanotify03.c: added forks_child when define struct tst_test

### DIFF
--- a/testcases/kernel/syscalls/fanotify/fanotify03.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify03.c
@@ -287,6 +287,7 @@ static struct tst_test test = {
 	.setup = setup,
 	.cleanup = cleanup,
 	.needs_tmpdir = 1,
+	.forks_child = 1,
 	.needs_root = 1
 };
 


### PR DESCRIPTION
Fix the failure of "tst_test.c:361: BROK: test.forks_child must be set!"

Signed-off-by: Xiao Liang <xiliang@redhat.com>