### PR TITLE
mtest05/mmstress: correct the case number if run with "-n"

### DIFF
--- a/testcases/kernel/mem/mtest05/mmstress.c
+++ b/testcases/kernel/mem/mtest05/mmstress.c
@@ -121,7 +121,6 @@
 #define FAILED       (-1)	/* return status for all funcs indicating failure   */
 #define SUCCESS      0		/* return status for all routines indicating success */
 
-#define MAXTEST      6		/* total number of testcase in this program          */
 #define BRKSZ        512*1024	/* program data space allocation value          */
 
 static volatile int wait_thread;	/* used to wake up sleeping threads    */
@@ -706,10 +705,10 @@ int main(int argc, char **argv)
 
 	do {
 		if (!test_num) {
-			for (i = 0; i < MAXTEST; i++)
+			for (i = 0; i < ARRAY_SIZE(test_ptr); i++)
 				run_test(i);
 		} else {
-			if (test_num > MAXTEST) {
+			if (test_num > ARRAY_SIZE(test_ptr)) {
 				tst_brkm(TBROK, NULL, "Invalid test number %i",
 					 test_num);
 			}

--- a/testcases/kernel/mem/mtest05/mmstress.c
+++ b/testcases/kernel/mem/mtest05/mmstress.c
@@ -709,12 +709,12 @@ int main(int argc, char **argv)
 			for (i = 0; i < MAXTEST; i++)
 				run_test(i);
 		} else {
-			if (test_num >= MAXTEST) {
+			if (test_num > MAXTEST) {
 				tst_brkm(TBROK, NULL, "Invalid test number %i",
 					 test_num);
 			}
 
-			run_test(test_num);
+			run_test(test_num-1);
 		}
 	} while (!run_once);
 


### PR DESCRIPTION
All cases are stored in array "test_ptr" which index starts from 0.
It is incorrect if user specifies test case in 1~6.

For example, it runs test2 when specified to run test1. Also, user cannot run
test1 by passing 0 to it, it will run all 6 cases instead.
$./mmstress -n 1
mmstress    0  TINFO  :  test2: Test case tests the race condition between
simultaneous write faults in the same address space.
mmstress    1  TPASS  :  TEST 2 Passed

Signed-off-by: Xiao Liang <xiliang@redhat.com>