### PR TITLE
testcases: fix mmapstress08 test

### DIFF
--- a/testcases/kernel/mem/mmapstress/mmapstress08.c
+++ b/testcases/kernel/mem/mmapstress/mmapstress08.c
@@ -81,7 +81,6 @@ extern long sysconf(int name);
 		local_flag = FAILED;
 		anyfail();
 	}
-	mmapaddr = 0;
 	/* burn level 2 ptes by spacing mmaps 4Meg apart */
 	/* This should switch to large anonymous swap space granularity */
 	for (i = 0; i < GRAN_NUMBER; i++) {


### PR DESCRIPTION
```
# ./runltp -f mm -s mmapstress08
...
<<<test_start>>>                                                                                                                                       │······
tag=mmapstress08 stime=1505791098                                                                                                                      │······
cmdline="mmapstress08"                                                                                                                                 │······
contacts=""                                                                                                                                            │······
analysis=exit                                                                                                                                          │······
<<<test_output>>>                                                                                                                                      │······
incrementing stop                                                                                                                                      │······
mmapstress08: errno = 22: munmap failed                                                                                                                │······
mmapstress08    1  TFAIL  :  mmapstress08.c:117: Test failed                                                                                           │······
                                                                                                                                                       │······
<<<execution_status>>> 
...
```

if sbrk(0) return a huge address, test failed.
mmapaddr should not be set to 0 here.