### PR TITLE
syscalls/clone: handle CLONE_VM vs exit issue

### DIFF
--- a/testcases/kernel/syscalls/clone/clone02.c
+++ b/testcases/kernel/syscalls/clone/clone02.c
@@ -270,8 +270,8 @@ static int child_fn(void)
 
 	if (test_VM() == 0 && test_FILES() == 0 && test_FS() == 0 &&
 	    test_SIG() == 0)
-		exit(0);
-	exit(1);
+		_exit(0);
+	_exit(1);
 }
 
 static int parent_test1(void)

--- a/testcases/kernel/syscalls/clone/clone05.c
+++ b/testcases/kernel/syscalls/clone/clone05.c
@@ -99,5 +99,5 @@ static int child_fn(void *unused __attribute__((unused)))
 	}
 
 	child_exited = 1;
-	exit(1);
+	_exit(1);
 }


### PR DESCRIPTION
CLONE_VM without CLONE_THREAD means that exit() from child process
will call all library destructors. As the VM is shared it means
that parent process will not be able to safely call any function
from library that depends on existence of its state.

Use _exit() instead of exit() in the child process to prevent library
destructors from being called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linux-test-project/ltp/208)
<!-- Reviewable:end -->
