### PR TITLE
lib/test_net.sh: Setup addresses to run network cases crossing 2 nodes.

### DIFF
--- a/testcases/lib/test_net.sh
+++ b/testcases/lib/test_net.sh
@@ -667,5 +667,14 @@ export RHOST_IFACES="${RHOST_IFACES:-eth0}"
 export LHOST_HWADDRS="${LHOST_HWADDRS:-$(tst_get_hwaddrs lhost)}"
 export RHOST_HWADDRS="${RHOST_HWADDRS:-$(tst_get_hwaddrs rhost)}"
 
+# Init LHOST and RHOST addresses if run test over 2 nodes
+if [[ ! -z $RHOST ]]; then
+	tst_add_ipaddr
+	tst_add_ipaddr rhost
+	tst_init_iface
+	tst_init_iface rhost
+	tst_wait_ipv6_dad
+fi
+
 # More information about network parameters can be found
 # in the following document: testcases/network/stress/README

--- a/testcases/lib/test_net.sh
+++ b/testcases/lib/test_net.sh
@@ -669,10 +669,10 @@ export RHOST_HWADDRS="${RHOST_HWADDRS:-$(tst_get_hwaddrs rhost)}"
 
 # Init LHOST and RHOST addresses if run test over 2 nodes
 if [[ ! -z $RHOST ]]; then
-	tst_add_ipaddr
-	tst_add_ipaddr rhost
 	tst_init_iface
 	tst_init_iface rhost
+	tst_add_ipaddr
+	tst_add_ipaddr rhost
 	tst_wait_ipv6_dad
 fi
 


### PR DESCRIPTION
It does not setup IPs on remote system which cause network cases fail.

Signed-off-by: Xiao Liang <xiliang@redhat.com>