### PR TITLE
Fix small issue on isofs.sh testcase

### DIFF
--- a/testcases/kernel/fs/iso9660/isofs.sh
+++ b/testcases/kernel/fs/iso9660/isofs.sh
@@ -102,6 +102,8 @@ gen_fs_tree "$MAKE_FILE_SYS_DIR" 1
 # Make ISO9660 file system with different options.
 # Mount the ISO9660 file system with different mount options.
 
+tst_check_cmds mkisofs
+
 for mkisofs_opt in \
 	" " \
 	"-J" \


### PR DESCRIPTION
The isofs.sh testcase was failing on Ubuntu, because it does not have
the mkisofs package installed by default.
Adding 'tst_check_cmds mkisofs' in the code can show that the package is
missing instead of throw an error.

Signed-off-by: Rodrigo R. Galvao <rosattig@linux.vnet.ibm.com>