### PR TITLE
tcp_cmds/echo: fix the connection refused problem in echo01 test

### DIFF
--- a/testcases/network/tcp_cmds/echo/echo01
+++ b/testcases/network/tcp_cmds/echo/echo01
@@ -103,8 +103,8 @@ do_test()
 
         incr_tst_count
         if [ $TST_COUNT -le $NUMLOOPS ]; then
-            tst_resm TINFO "Sleeping 60 seconds to avoid hitting max. connections setting for service"
-            sleep 60
+            tst_resm TINFO "Sleeping 80 seconds to avoid hitting max. connections setting for service"
+            sleep 80
         fi
     done
 }

--- a/testcases/network/tcp_cmds/echo/echoes.c
+++ b/testcases/network/tcp_cmds/echo/echoes.c
@@ -75,6 +75,7 @@ int main(int argc, char *argv[], char *env[])
 	i = (unsigned int)strtol(argv[3], NULL, 10);
 	j = 0;
 	while (i-- > 0) {
+		sp->s_port++;
 		switch (pid = fork()) {
 		case 0:
 			snprintf(echo_struc[j].resultfile,
@@ -228,6 +229,12 @@ echofile(struct servent *sp, struct addrinfo *ai, char *resultfile,
 #else
 	sa.sin_port = port;
 #endif
+	if (bind(s,(sa_t *) & sa, sizeof(sa)) < 0 ) {
+		tst_resm(TBROK, "Failed to bind socket (pid=%d)",
+			 pid);
+		cleanup(s);
+		tst_exit();
+	}
 
 	if (connect(s, (sa_t *) & sa, sizeof(sa)) == -1) {
 		tst_resm(TBROK | TERRNO,


### PR DESCRIPTION
The test always failed as multi connections to the same port and no
bind operation after socket created.
Bind it and increase port# for each new pid to fix this problem.

Error message:
Creating socket .....
echoes      1  TBROK  :  echoes.c:234: failed to create connector socket
(pid=17910): errno=ECONNREFUSED(111): Connection refused

Signed-off-by: Xiao Liang <xiliang@redhat.com>