### PR TITLE
syscalls: nullwrite [RFC]

### DIFF
--- a/testcases/kernel/syscalls/pwrite/pwrite02.c
+++ b/testcases/kernel/syscalls/pwrite/pwrite02.c
@@ -174,6 +174,16 @@ static void test_efault(void)
 
 	fd = SAFE_OPEN(TEMPFILE, O_RDWR | O_CREAT, 0666);
 
+	TEST(pwrite(fd, NULL, 0, 0));
+
+	if (TEST_RETURN == 0) {
+		tst_res(TPASS, "pwrite succeeded as expected with count = 0");
+	} else {
+		tst_res(TFAIL, "pwrite failed unexpectedly; "
+			"return: %ld with errno %d (%s)",
+			TEST_RETURN, TEST_ERRNO, tst_strerrno(TEST_ERRNO));
+	}
+
 	TEST(pwrite(fd, buf, K1, 0));
 
 	print_test_result(TEST_ERRNO, EFAULT);

--- a/testcases/kernel/syscalls/pwrite/pwrite02.c
+++ b/testcases/kernel/syscalls/pwrite/pwrite02.c
@@ -35,20 +35,16 @@
 
 #include <errno.h>
 #include <unistd.h>
-#include <fcntl.h>
+#include <string.h>
 
-#include "test.h"
-#include "safe_macros.h"
+#include "tst_test.h"
 
 #define TEMPFILE	"pwrite_file"
 #define K1		1024
 
-TCID_DEFINE(pwrite02);
-
 static char write_buf[K1];
 
 static void setup(void);
-static void cleanup(void);
 
 static void test_espipe(void);
 static void test_einval(void);
@@ -66,25 +62,9 @@ static void (*testfunc[])(void) = {
 #endif
 };
 
-int TST_TOTAL = ARRAY_SIZE(testfunc);
-
-int main(int ac, char **av)
+static void verify_pwrite(unsigned int i)
 {
-	int i, lc;
-
-	tst_parse_opts(ac, av, NULL, NULL);
-
-	setup();
-
-	for (lc = 0; TEST_LOOPING(lc); lc++) {
-		tst_count = 0;
-
-		for (i = 0; i < TST_TOTAL; i++)
-			(*testfunc[i])();
-	}
-
-	cleanup();
-	tst_exit();
+	(*testfunc[i])();
 }
 
 /*
@@ -111,16 +91,10 @@ static void sighandler(int sig)
 
 static void setup(void)
 {
-	tst_sig(NOFORK, DEF_HANDLER, cleanup);
-
 	/* see the comment in the sighandler() function */
 	/* call signal() to trap the signal generated */
 	if (signal(SIGXFSZ, sighandler) == SIG_ERR)
-		tst_brkm(TBROK, cleanup, "signal() failed");
-
-	TEST_PAUSE;
-
-	tst_tmpdir();
+		tst_brk(TBROK | TERRNO, "signal() failed");
 
 	memset(write_buf, 'a', K1);
 }
@@ -128,17 +102,17 @@ static void setup(void)
 static void print_test_result(int err, int exp_errno)
 {
 	if (err == 0) {
-		tst_resm(TFAIL, "call succeeded unexpectedly");
+		tst_res(TFAIL, "call succeeded unexpectedly");
 		return;
 	}
 
 	if (err == exp_errno) {
-		tst_resm(TPASS, "pwrite failed as expected: %d - %s",
-			 err, strerror(err));
+		tst_res(TPASS, "pwrite failed as expected: %d - %s",
+			err, tst_strerrno(err));
 	} else {
-		tst_resm(TFAIL, "pwrite failed unexpectedly; expected: %d - %s"
-			 "return: %d - %s", exp_errno, strerror(exp_errno),
-			 err, strerror(err));
+		tst_res(TFAIL, "pwrite failed unexpectedly; expected: %d - %s"
+			"return: %d - %s", exp_errno, tst_strerrno(exp_errno),
+			err, tst_strerrno(err));
 	}
 }
 
@@ -146,28 +120,28 @@ static void test_espipe(void)
 {
 	int pipe_fds[2];
 
-	SAFE_PIPE(cleanup, pipe_fds);
+	SAFE_PIPE(pipe_fds);
 
 	TEST(pwrite(pipe_fds[1], write_buf, K1, 0));
 
-	print_test_result(errno, ESPIPE);
+	print_test_result(TEST_ERRNO, ESPIPE);
 
-	SAFE_CLOSE(cleanup, pipe_fds[0]);
-	SAFE_CLOSE(cleanup, pipe_fds[1]);
+	SAFE_CLOSE(pipe_fds[0]);
+	SAFE_CLOSE(pipe_fds[1]);
 }
 
 static void test_einval(void)
 {
 	int fd;
 
-	fd = SAFE_OPEN(cleanup, TEMPFILE, O_RDWR | O_CREAT, 0666);
+	fd = SAFE_OPEN(TEMPFILE, O_RDWR | O_CREAT, 0666);
 
 	/* the specified offset was invalid */
 	TEST(pwrite(fd, write_buf, K1, -1));
 
-	print_test_result(errno, EINVAL);
+	print_test_result(TEST_ERRNO, EINVAL);
 
-	SAFE_CLOSE(cleanup, fd);
+	SAFE_CLOSE(fd);
 }
 
 static void test_ebadf1(void)
@@ -176,20 +150,20 @@ static void test_ebadf1(void)
 
 	TEST(pwrite(fd, write_buf, K1, 0));
 
-	print_test_result(errno, EBADF);
+	print_test_result(TEST_ERRNO, EBADF);
 }
 
 static void test_ebadf2(void)
 {
 	int fd;
 
-	fd = SAFE_OPEN(cleanup, TEMPFILE, O_RDONLY | O_CREAT, 0666);
+	fd = SAFE_OPEN(TEMPFILE, O_RDONLY | O_CREAT, 0666);
 
 	TEST(pwrite(fd, write_buf, K1, 0));
 
-	print_test_result(errno, EBADF);
+	print_test_result(TEST_ERRNO, EBADF);
 
-	SAFE_CLOSE(cleanup, fd);
+	SAFE_CLOSE(fd);
 }
 
 #if !defined(UCLINUX)
@@ -198,17 +172,19 @@ static void test_efault(void)
 	int fd;
 	char *buf = sbrk(0);
 
-	fd = SAFE_OPEN(cleanup, TEMPFILE, O_RDWR | O_CREAT, 0666);
+	fd = SAFE_OPEN(TEMPFILE, O_RDWR | O_CREAT, 0666);
 
 	TEST(pwrite(fd, buf, K1, 0));
 
-	print_test_result(errno, EFAULT);
+	print_test_result(TEST_ERRNO, EFAULT);
 
-	SAFE_CLOSE(cleanup, fd);
+	SAFE_CLOSE(fd);
 }
 #endif
 
-static void cleanup(void)
-{
-	tst_rmdir();
-}
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.test = verify_pwrite,
+	.tcnt = ARRAY_SIZE(testfunc),
+};

--- a/testcases/kernel/syscalls/write/write04.c
+++ b/testcases/kernel/syscalls/write/write04.c
@@ -51,152 +51,126 @@
 #include <setjmp.h>
 #include <errno.h>
 #include <string.h>
-#include "test.h"
+#include <stdio.h>
+#include "tst_test.h"
 
 #define PIPE_SIZE_TEST getpagesize()
 
 void alarm_handler();
-void setup();
-void cleanup();
-
-char *TCID = "write04";
-int TST_TOTAL = 1;
 
 char fifo[100] = "fifo";
 static sigjmp_buf jmp;
 int rfd, wfd;
 
-int main(int argc, char **argv)
+static void verify_write(void)
 {
-	int lc;
-
 	struct stat buf;
 	int fail;
 	int cnt;
 	char wbuf[17 * PIPE_SIZE_TEST];
 	struct sigaction sigptr;	/* set up signal handler */
 
-	tst_parse_opts(argc, argv, NULL, NULL);
+	if (mknod(fifo, S_IFIFO | 0777, 0) < 0)
+		tst_res(TBROK | TERRNO, "mknod() failed, errno: %d", errno);
 
-	/* global setup */
-	setup();
+	if (stat(fifo, &buf) != 0)
+		tst_res(TBROK | TERRNO, "stat() failed, errno: %d", errno);
+
+	if ((buf.st_mode & S_IFIFO) == 0)
+		tst_res(TBROK | TERRNO, "Mode does not indicate fifo file");
+
+#if 0
+	sigset(SIGALRM, alarm_handler);
+#endif
+	sigptr.sa_handler = (void (*)(int signal))alarm_handler;
+	sigfillset(&sigptr.sa_mask);
+	sigptr.sa_flags = 0;
+	sigaddset(&sigptr.sa_mask, SIGALRM);
+	if (sigaction(SIGALRM, &sigptr, NULL) == -1)
+		tst_res(TBROK | TERRNO, "sigaction(): Failed");
+
+//block1:
+	tst_res(TINFO, "Enter block 1: test for EAGAIN in write()");
+	fail = 0;
+
+	(void)memset((void *)wbuf, 'A', 17 * PIPE_SIZE_TEST);
 
 	/*
-	 * The following loop checks looping state if -i option given
+	 * open the read end of the pipe
 	 */
-	for (lc = 0; TEST_LOOPING(lc); lc++) {
-		/* reset tst_count in case we are looping */
-		tst_count = 0;
-
-		if (mknod(fifo, S_IFIFO | 0777, 0) < 0) {
-			tst_resm(TBROK, "mknod() failed, errno: %d", errno);
-			cleanup();
-		}
-		if (stat(fifo, &buf) != 0) {
-			tst_resm(TBROK, "stat() failed, errno: %d", errno);
-			cleanup();
-		}
-		if ((buf.st_mode & S_IFIFO) == 0) {
-			tst_resm(TBROK, "Mode does not indicate fifo file");
-			cleanup();
-		}
-#if 0
-		sigset(SIGALRM, alarm_handler);
-#endif
-		sigptr.sa_handler = (void (*)(int signal))alarm_handler;
-		sigfillset(&sigptr.sa_mask);
-		sigptr.sa_flags = 0;
-		sigaddset(&sigptr.sa_mask, SIGALRM);
-		if (sigaction(SIGALRM, &sigptr, NULL) == -1) {
-			tst_resm(TBROK, "sigaction(): Failed");
-			cleanup();
-		}
-//block1:
-		tst_resm(TINFO, "Enter block 1: test for EAGAIN in write()");
-		fail = 0;
-
-		(void)memset((void *)wbuf, 'A', 17 * PIPE_SIZE_TEST);
-
-		/*
-		 * open the read end of the pipe
-		 */
-		if (sigsetjmp(jmp, 1)) {
-			tst_resm(TBROK, "Error reading fifo, read blocked");
-			fail = 1;
-		}
-		(void)alarm(10);	/* set alarm for 10 seconds */
-		rfd = open(fifo, O_RDONLY | O_NONBLOCK);
-		(void)alarm(0);
-		if (rfd < 0) {
-			tst_resm(TBROK, "open() for reading the pipe failed");
-			fail = 1;
-		}
-
-		/*
-		 * open the write end of the pipe
-		 */
-		if (sigsetjmp(jmp, 1)) {
-			tst_resm(TBROK, "setjmp() failed");
-			cleanup();
-		}
-		(void)alarm(10);	/* set alarm for 10 seconds */
-		wfd = open(fifo, O_WRONLY | O_NONBLOCK);
-		(void)alarm(0);
-		if (wfd < 0) {
-			tst_resm(TBROK, "open() for writing the pipe failed");
-			fail = 1;
-		}
-
-		/*
-		 * attempt to fill the pipe with some data
-		 */
-		if (sigsetjmp(jmp, 1)) {
-			tst_resm(TBROK, "sigsetjmp() failed");
-			fail = 1;
-		}
-		(void)alarm(10);
-		cnt = write(wfd, wbuf, 17 * PIPE_SIZE_TEST);
-		(void)alarm(0);
-		if (cnt == 17 * PIPE_SIZE_TEST) {
-			tst_resm(TBROK, "Error reading fifo, nozero read");
-			fail = 1;
-		}
-
-		/*
-		 * Now that the fifo is full try and send some more
-		 */
-		if (sigsetjmp(jmp, 1)) {
-			tst_resm(TBROK, "sigsetjmp() failed");
-			fail = 1;
-		}
-		(void)alarm(10);
-		cnt = write(wfd, wbuf, 8 * PIPE_SIZE_TEST);
-		(void)alarm(0);
-		if (cnt != -1) {
-			tst_resm(TBROK, "write() failed to fail when pipe "
-				 "is full");
-			fail = 1;
-		} else {
-			if (errno != EAGAIN) {
-				tst_resm(TBROK, "write set bad errno, expected "
-					 "EAGAIN, got %d", errno);
-				fail = 1;
-			}
-			tst_resm(TINFO, "read() succeded in setting errno to "
-				 "EAGAIN");
-		}
-		if (fail) {
-			tst_resm(TFAIL, "Block 1 FAILED");
-		} else {
-			tst_resm(TPASS, "Block 1 PASSED");
-		}
-		tst_resm(TINFO, "Exit block 1");
-
-		/* unlink fifo in case we are looping. */
-		unlink(fifo);
+	if (sigsetjmp(jmp, 1)) {
+		tst_res(TBROK | TERRNO, "Error reading fifo, read blocked");
+		fail = 1;
 	}
-	cleanup();
-	tst_exit();
+	(void)alarm(10);	/* set alarm for 10 seconds */
+	rfd = open(fifo, O_RDONLY | O_NONBLOCK);
+	(void)alarm(0);
+	if (rfd < 0) {
+		tst_res(TBROK | TERRNO, "open() for reading the pipe failed");
+		fail = 1;
+	}
+
+	/*
+	 * open the write end of the pipe
+	 */
+	if (sigsetjmp(jmp, 1))
+		tst_res(TBROK | TERRNO, "setjmp() failed");
+
+	(void)alarm(10);	/* set alarm for 10 seconds */
+	wfd = open(fifo, O_WRONLY | O_NONBLOCK);
+	(void)alarm(0);
+	if (wfd < 0) {
+		tst_res(TBROK | TERRNO, "open() for writing the pipe failed");
+		fail = 1;
+	}
+
+	/*
+	 * attempt to fill the pipe with some data
+	 */
+	if (sigsetjmp(jmp, 1)) {
+		tst_res(TBROK | TERRNO, "sigsetjmp() failed");
+		fail = 1;
+	}
+	(void)alarm(10);
+	cnt = write(wfd, wbuf, 17 * PIPE_SIZE_TEST);
+	(void)alarm(0);
+	if (cnt == 17 * PIPE_SIZE_TEST) {
+		tst_res(TBROK | TERRNO, "Error reading fifo, nozero read");
+		fail = 1;
+	}
+
+	/*
+	 * Now that the fifo is full try and send some more
+	 */
+	if (sigsetjmp(jmp, 1)) {
+		tst_res(TBROK | TERRNO, "sigsetjmp() failed");
+		fail = 1;
+	}
+	(void)alarm(10);
+	cnt = write(wfd, wbuf, 8 * PIPE_SIZE_TEST);
+	(void)alarm(0);
+	if (cnt != -1) {
+		tst_res(TBROK | TERRNO, "write() failed to fail when pipe "
+			"is full");
+		fail = 1;
+	} else {
+		if (errno != EAGAIN) {
+			tst_res(TBROK, "write set bad errno, expected "
+				"EAGAIN, got %d", errno);
+			fail = 1;
+		}
+		tst_res(TINFO, "write() succeded in setting errno to "
+			"EAGAIN");
+	}
+	if (fail) {
+		tst_res(TFAIL, "Block 1 FAILED");
+	} else {
+		tst_res(TPASS, "Block 1 PASSED");
+	}
+	tst_res(TINFO, "Exit block 1");
+
+	/* unlink fifo in case we are looping. */
+	unlink(fifo);
 }
 
 void alarm_handler(void)
@@ -208,32 +182,24 @@ void alarm_handler(void)
  * setup()
  *	performs all ONE TIME setup for this test
  */
-void setup(void)
+static void setup(void)
 {
-
-	tst_sig(FORK, DEF_HANDLER, cleanup);
-
-	/* Pause if that option was specified
-	 * TEST_PAUSE contains the code to fork the test with the -i option.
-	 * You want to make sure you do this before you create your temporary
-	 * directory.
-	 */
-	TEST_PAUSE;
-
-	/* Create a unique temporary directory and chdir() to it. */
-	tst_tmpdir();
-
 	/* create a temporary filename */
 	sprintf(fifo, "%s.%d", fifo, getpid());
-
 }
 
-void cleanup(void)
+static void cleanup(void)
 {
-
-	close(rfd);
-	close(wfd);
+	if (rfd > 0)
+		SAFE_CLOSE(rfd);
+	if (wfd > 0)
+		SAFE_CLOSE(wfd);
 	unlink(fifo);
-	tst_rmdir();
-
 }
+
+static struct tst_test test = {
+	.needs_tmpdir = 1,
+	.setup = setup,
+	.cleanup = cleanup,
+	.test_all = verify_write,
+};

--- a/testcases/kernel/syscalls/write/write05.c
+++ b/testcases/kernel/syscalls/write/write05.c
@@ -91,6 +91,15 @@ static void verify_write(void)
 	if (fd < 0)
 		tst_res(TFAIL, "creating a new file failed");
 
+//block2.1:
+	if (write(fd, NULL, 0) != 0) {
+		tst_res(TFAIL, "write() with nsize 0 in a "
+				"valid fd failed with errno: %d, "
+				"but should have succeeded", errno);
+	} else {
+		tst_res(TPASS, "succeeded as expected with nsize = 0");
+	}
+//block2.2"
 	if (write(fd, bad_addr, 10) != -1) {
 		tst_res(TFAIL, "write() on an invalid buffer "
 			"succeeded, but should have failed");
@@ -99,8 +108,8 @@ static void verify_write(void)
 			tst_res(TFAIL, "write() returned illegal "
 				 "errno: expected EFAULT, got %d",
 				 errno);
-			}
-			tst_res(TPASS, "received EFAULT as expected.");
+		}
+		tst_res(TPASS, "received EFAULT as expected.");
 	}
 	tst_res(TINFO, "Exit Block 2");
 


### PR DESCRIPTION
check for a special case of write, when a NULL buffer is used with a size of 0 and which result in a 0 response, instead of -1 (EFAULT)