### PR TITLE
kernel/fs/doio/rwtest: Fix test case failed issue when blks is zero

### DIFF
--- a/testcases/kernel/fs/doio/rwtest
+++ b/testcases/kernel/fs/doio/rwtest
@@ -344,7 +344,7 @@ do
 
 			# check if blks is a number, else set a default value for blks
 			default_sz=1000000
-			if [ $blks -eq $blks 2> /dev/null ]
+			if [ $blks -eq $blks 2> /dev/null -a $blks -gt 0 ]
 			then
 
 				case $(uname) in


### PR DESCRIPTION
If blks is a number zero, we should set a default value to it.
Otherwise, test cases rwtest01-04 will fail.

Signed-off-by: Shaoting Lei <leist.fnst@cn.fujitsu.com>