### PR TITLE
commands: nm: fix typo INSTALL_TARTGETS -> INSTALL_TARGETS

### DIFF
--- a/testcases/commands/nm/datafiles/Makefile
+++ b/testcases/commands/nm/datafiles/Makefile
@@ -15,7 +15,7 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/env_pre.mk
 INSTALL_DIR		:= testcases/data/nm01
-INSTALL_TARTGETS	:= f1 f2 f3 lib.a
+INSTALL_TARGETS		:= f1 f2 f3 lib.a
 MAKE_TARGETS		+= f1 f2 f3 lib.a
 
 lib.a: f1.o f2.o f3.o


### PR DESCRIPTION
Fix the typo preventing to install the files.

cp: cannot stat '/opt/ltp/testcases/data/nm01/lib.a': No such file or
directory
1 TBROK: cp /opt/ltp/testcases/data/nm01/lib.a . failed

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>