### PR TITLE
fanotify: fix build failure with -Werror=format-security

### DIFF
--- a/testcases/kernel/syscalls/fanotify/fanotify08.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify08.c
@@ -53,9 +53,9 @@ static void test_init_bit(unsigned int fan_bit,
 	ret = SAFE_FCNTL(fd_notify, F_GETFD);
 
 	if ((ret & FD_CLOEXEC) == fd_bit) {
-		tst_res(TPASS, msg);
+		tst_res(TPASS, "%s", msg);
 	} else {
-		tst_res(TFAIL, msg);
+		tst_res(TFAIL, "%s", msg);
 	}
 
 	SAFE_CLOSE(fd_notify);


### PR DESCRIPTION
fanotify08.c:56:3: error: format not a string literal and no format arguments [-Werror=format-security]
   tst_res(TPASS, msg);
   ^~~~~~~
fanotify08.c:58:3: error: format not a string literal and no format arguments [-Werror=format-security]
   tst_res(TFAIL, msg);
   ^~~~~~~

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>