### PR TITLE
containers: netns: load veth module

### DIFF
--- a/testcases/kernel/containers/README
+++ b/testcases/kernel/containers/README
@@ -28,7 +28,7 @@ CONFIG_IPC_NS=y
 CONFIG_USER_NS=y
 CONFIG_PID_NS=y
 CONFIG_NET_NS=y
-CONFIG_VETH=y
+CONFIG_VETH=y(or =m)
 CONFIG_MACVLAN=y(optional)
 
 The container test automation suite helps run the container functionality

--- a/testcases/kernel/containers/netns/netns_helper.sh
+++ b/testcases/kernel/containers/netns/netns_helper.sh
@@ -110,7 +110,9 @@ tst_check_iproute()
 netns_setup()
 {
 	tst_require_root
-	tst_check_cmds ip
+	tst_check_cmds ip modprobe
+
+	modprobe veth > /dev/null 2>&1
 
 	case "$1" in
 	ns_exec)


### PR DESCRIPTION
Most of regular distributions are shipping the virtual ethernet driver as
a kernel module. The test assumes it's built-in.
Attempt to load the veth module in the netns_setup() function.
It will allow to get the tests running on a distro kernel and avoid to
build a custom kernel for LTP purpose.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>