### PR TITLE
Fix condition

### DIFF
--- a/lib/tlibio.c
+++ b/lib/tlibio.c
@@ -1869,7 +1869,7 @@ int lio_wait4asyncio(int method, int fd, struct aiocb *aiocbp)
 		cnt = 0;
 		while (1) {
 			ret = aio_error(aiocbp);
-			if ((ret == 0) || (ret != EINPROGRESS)) {
+			if (ret != EINPROGRESS) {
 				break;
 			}
 			++cnt;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:
ltp/lib/tlibio.c    1872    err     V590 Consider inspecting the '(ret == 0) || (ret != 115)' expression. The expression is excessive or contains a misprint.

0 != 15, so the condition will always have true in`0` case too. Just simplify code.