### PR TITLE
ima/ima_measurements.sh: Fix a minor typo of '$($date)'

### DIFF
--- a/testcases/kernel/security/integrity/ima/tests/ima_measurements.sh
+++ b/testcases/kernel/security/integrity/ima/tests/ima_measurements.sh
@@ -76,7 +76,7 @@ test01()
 test02()
 {
 	# Modify test.txt
-	echo $($date) - file modified >> test.txt
+	echo $(date) - file modified >> test.txt
 
 	# Calculating the sha1sum of test.txt should add
 	# the new measurement to the measurement list


### PR DESCRIPTION
Signed-off-by: Xiao Liang <xiliang@redhat.com>