### PR TITLE
generate.sh: support reproducible build

### DIFF
--- a/testcases/network/generate.sh
+++ b/testcases/network/generate.sh
@@ -55,7 +55,7 @@ fi
 if [ ! -e "bin.sm" ] ; then
 	cnt=0
 	while [ $cnt -lt 5 ] ; do
-		gzip -1 -c ascii.sm >> "bin.sm"
+		gzip -1 -c -n ascii.sm >> "bin.sm"
 		cnt=$(($cnt + 1))
 	done
 fi


### PR DESCRIPTION
Do not generate timestamps in gzipped headers.
The timestamps prevent reproducible builds.

https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>