### PR TITLE
controllers/pids.sh: add some extra testcases

### DIFF
--- a/runtest/controllers
+++ b/runtest/controllers
@@ -354,24 +354,42 @@ cpuset_regression_test cpuset_regression_test.sh
 
 cgroup_xattr	cgroup_xattr
 
-pids_1_1 pids.sh 1 1
-pids_1_2 pids.sh 1 2
-pids_1_10 pids.sh 1 10
-pids_1_50 pids.sh 1 50
-pids_1_100 pids.sh 1 100
-pids_2_1 pids.sh 2 1
-pids_2_2 pids.sh 2 2
-pids_2_10 pids.sh 2 10
-pids_2_50 pids.sh 2 50
-pids_2_100 pids.sh 2 100
-pids_3_0 pids.sh 3 0
-pids_3_1 pids.sh 3 1
-pids_3_10 pids.sh 3 10
-pids_3_50 pids.sh 3 50
-pids_3_100 pids.sh 3 100
-pids_4_1 pids.sh 4 1
-pids_4_2 pids.sh 4 2
-pids_4_10 pids.sh 4 10
-pids_4_50 pids.sh 4 50
-pids_4_100 pids.sh 4 100
-pids_5_1 pids.sh 5 1
+pids_1_1 pids.sh 1 1 0
+pids_1_2 pids.sh 1 2 0
+pids_1_10 pids.sh 1 10 0
+pids_1_50 pids.sh 1 50 0
+pids_1_100 pids.sh 1 100 0
+pids_2_1 pids.sh 2 1 0
+pids_2_2 pids.sh 2 2 0
+pids_2_10 pids.sh 2 10 0
+pids_2_50 pids.sh 2 50 0
+pids_2_100 pids.sh 2 100 0
+pids_3_0 pids.sh 3 0 0
+pids_3_1 pids.sh 3 1 0
+pids_3_10 pids.sh 3 10 0
+pids_3_50 pids.sh 3 50 0
+pids_3_100 pids.sh 3 100 0
+pids_4_1 pids.sh 4 1 0
+pids_4_2 pids.sh 4 2 0
+pids_4_10 pids.sh 4 10 0
+pids_4_50 pids.sh 4 50 0
+pids_4_100 pids.sh 4 100 0
+pids_5_1 pids.sh 5 1 0
+pids_6_1 pids.sh 6 1 0
+pids_6_2 pids.sh 6 2 0
+pids_6_10 pids.sh 6 10 0
+pids_6_50 pids.sh 6 50 0
+pids_6_100 pids.sh 6 100 0
+pids_7_10 pids.sh 7 10 5
+pids_7_50 pids.sh 7 50 10
+pids_7_100 pids.sh 7 100 10
+pids_7_100 pids.sh 7 500 50 
+pids_7_100 pids.sh 7 1000 100
+pids_8_2 pids.sh 8 2 0
+pids_8_10 pids.sh 8 10 0
+pids_8_50 pids.sh 8 50 0
+pids_8_100 pids.sh 8 100 0
+pids_9_2 pids.sh 9 2 0
+pids_9_10 pids.sh 9 10 0
+pids_9_50 pids.sh 9 50 0
+pids_9_100 pids.sh 9 100 0

--- a/testcases/kernel/controllers/pids/pids.sh
+++ b/testcases/kernel/controllers/pids/pids.sh
@@ -29,7 +29,7 @@
 TST_CLEANUP=cleanup
 TST_SETUP=setup
 TST_TESTFUNC=do_test
-TST_POS_ARGS=2
+TST_POS_ARGS=3
 TST_USAGE=usage
 TST_NEEDS_ROOT=1
 
@@ -37,6 +37,7 @@ TST_NEEDS_ROOT=1
 
 caseno=$1
 max=$2
+subcgroup_num=$3
 mounted=1
 
 usage()
@@ -44,9 +45,11 @@ usage()
 	cat << EOF
 usage: $0 caseno max_processes
 
-caseno        - testcase number from interval 1-5
+caseno        - testcase number from interval 1-9
 max_processes - maximal number of processes to attach
-                (applicable to testcase 1-4)
+                (not applicable to testcase 5)
+subcgroup_num - number of subgroups created in group
+		(only applicable to testcase 7)
 OPTIONS
 EOF
 }
@@ -89,20 +92,33 @@ setup()
 
 start_pids_tasks2()
 {
-	nb=$1
+	start_pids_tasks2_path $testpath $1
+}
+
+start_pids_tasks2_path()
+{
+	path=$1
+	nb=$2
 	for i in `seq 1 $nb`; do
 		pids_task2 &
-		echo $! > $testpath/tasks
+		echo $! > $path/tasks
 	done
 
-	if [ $(cat "$testpath/tasks" | wc -l) -ne $nb ]; then
+	if [ $(cat "$path/tasks" | wc -l) -ne $nb ]; then
 		tst_brk TBROK "failed to attach process"
 	fi
 }
 
 stop_pids_tasks()
 {
-	for i in `cat $testpath/tasks`; do
+	stop_pids_tasks_path $testpath
+}
+
+stop_pids_tasks_path()
+{
+	local i
+	path=$1
+	for i in `cat $path/tasks`; do
 		ROD kill -9 $i
 		wait $i
 	done
@@ -194,6 +210,166 @@ case5()
 	else
 		tst_res TPASS "didn't manage to set the limit to -1"
 	fi
+}
+
+case6()
+{
+	tst_res TINFO "set a limit that is smaller than current number of pids"
+	start_pids_tasks2 $max
+
+	lim=$((max - 1))
+	ROD echo $lim \> $testpath/pids.max
+
+	pids_task1 "$testpath/tasks"
+	ret=$?
+
+	if [ "$ret" -eq "2" ]; then
+		tst_res TPASS "fork failed as expected"
+	elif [ "$ret" -eq "0" ]; then
+		tst_res TFAIL "fork didn't fail despite the limit"
+	else
+		tst_res TBROK "pids_task1 failed"
+	fi
+
+	stop_pids_tasks
+}
+
+case7()
+{
+	tst_res TINFO "the number of all child cgroup tasks larger than its parent limit"
+	
+	lim=$((max / subcgroup_num))
+	if [ "$((lim * subcgroup_num))" -ne "$max" ]; then
+		tst_res TWARN "input max value must be a multiplier of $subcgroup_num"
+		return
+	fi
+
+	ROD echo $max \> $testpath/pids.max
+
+	for i in `seq 1 $subcgroup_num`; do
+		mkdir $testpath/child$i
+		start_pids_tasks2_path $testpath/child$i $lim
+	done
+
+	pids_task1 "$testpath/tasks"
+	ret=$?
+
+	if [ "$ret" -eq "2" ]; then
+		tst_res TPASS "parent cgroup fork failed as expected"
+	elif [ "$ret" -eq "0" ]; then
+		tst_res TFAIL "parent cgroup fork didn't fail despite the limit"
+	else
+		tst_res TBROK "parent cgroup pids_task1 failed"
+	fi
+
+	for i in `seq 1 $subcgroup_num`; do
+		pids_task1 "$testpath/child$i/tasks"
+		ret=$?
+
+		if [ "$ret" -eq "2" ]; then
+			tst_res TPASS "child$i cgroup fork failed as expected"
+		elif [ "$ret" -eq "0" ]; then
+			tst_res TFAIL "child$i cgroup fork didn't fail despite the limit"
+		else
+			tst_res TBROK "child$i cgroup pids_task1 failed"
+		fi
+	done
+
+	for i in `seq 1 $subcgroup_num`; do
+		stop_pids_tasks_path $testpath/child$i
+		rmdir $testpath/child$i
+	done
+
+	stop_pids_tasks
+}
+
+case8()
+{
+	tst_res TINFO "set child cgroup limit smaller than its parent limit"
+	ROD echo $max \> $testpath/pids.max
+
+	mkdir $testpath/child
+
+	lim=$((max - 1))
+	ROD echo $lim \> $testpath/child/pids.max
+	tmp=$((max - 2))
+	start_pids_tasks2_path $testpath/child $tmp
+
+	pids_task1 "$testpath/child/tasks"
+	ret=$?
+
+	if [ "$ret" -eq "2" ]; then
+		tst_res TPASS "fork failed as expected"
+	elif [ "$ret" -eq "0" ]; then
+		tst_res TFAIL "fork didn't fail despite the limit"
+	else
+		tst_res TBROK "pids_task1 failed"
+	fi
+
+	stop_pids_tasks_path $testpath/child
+	rmdir $testpath/child
+	stop_pids_tasks_path
+}
+
+case9()
+{
+	tst_res TINFO "migrate cgroup"
+	lim=$((max - 1))
+
+	for i in `seq 1 2`; do
+		mkdir $testpath/child$i
+		ROD echo $max \> $testpath/child$i/pids.max
+		start_pids_tasks2_path $testpath/child$i $lim
+	done
+	
+	pid=`head -n 1 $testpath/child1/tasks`;
+	ROD echo $pid \> $testpath/child2/tasks
+
+	if grep -q "$pid" "$testpath/child2/tasks"; then
+		tst_res TPASS "migrate pid $pid from cgroup1 to cgroup2 as expected"
+	else
+		tst_res TPASS "migrate pid $pid from cgroup1 to cgroup2 failed"
+	fi
+
+	if [ $(cat "$testpath/child1/pids.current") -eq $((lim - 1)) ]; then
+		tst_res TPASS "migrate child1 cgroup as expected"
+	else
+		tst_res TFAIL "migrate child1 cgroup failed"
+	fi
+
+	if [ $(cat "$testpath/child2/pids.current") -eq $((lim + 1)) ]; then
+		tst_res TPASS "migrate child2 cgroup as expected"
+	else
+		tst_res TFAIL "migrate child2 cgroup failed"
+	fi
+
+	pids_task1 "$testpath/child1/tasks"
+	ret=$?
+
+	if [ "$ret" -eq "2" ]; then
+		tst_res TFAIL "child1 fork failed unexpectedly"
+	elif [ "$ret" -eq "0" ]; then
+		tst_res TPASS "child1 fork worked as expected"
+	else
+		tst_res TBROK "child1 pids_task1 failed"
+	fi
+
+	pids_task1 "$testpath/child2/tasks"
+	ret=$?
+
+	if [ "$ret" -eq "2" ]; then
+		tst_res TPASS "child2 fork failed as expected"
+	elif [ "$ret" -eq "0" ]; then
+		tst_res TFAIL "child2 fork didn't fail despite the limit"
+	else
+		tst_res TBROK "child2 pids_task1 failed"
+	fi
+
+	for i in `seq 1 2`; do
+		stop_pids_tasks_path $testpath/child$i
+		rmdir $testpath/child$i
+	done
+	stop_pids_tasks
 }
 
 do_test()


### PR DESCRIPTION
I think original controllers/pids.sh testcases are not overall, so I add some extra testcases.
As follows:
1. set a limit that is smaller than current number of pids
2. the number of all child cgroup tasks larger than its parent limit
3. set child cgroup limit smaller than its parent limit
4. migrate pids cgroup

Signed-off-by: Yang Pengfei <yangpengfei4@huawei.com>