### PR TITLE
CVE-2012-0957: fix false report with UNAME26 personality

### DIFF
--- a/testcases/cve/cve-2012-0957.c
+++ b/testcases/cve/cve-2012-0957.c
@@ -29,12 +29,15 @@
 #include "tst_test.h"
 #include "lapi/personality.h"
 
-static int check_field(char *bytes, size_t length, char *field)
+static struct utsname saved_buf;
+
+static int check_field(char *bytes, char *saved_bytes, size_t length,
+		       char *field)
 {
 	size_t i = strlen(bytes) + 1;
 
 	for (; i < length; i++) {
-		if (bytes[i]) {
+		if (bytes[i] && (bytes[i] != saved_bytes[i])) {
 			tst_res(TFAIL, "Bytes leaked in %s!", field);
 			return 1;
 		}
@@ -43,15 +46,21 @@ static int check_field(char *bytes, size_t length, char *field)
 }
 
 
-static void try_leak_bytes(void)
+static void try_leak_bytes(unsigned int test_nr)
 {
 	struct utsname buf;
+
+	memset(&buf, 0, sizeof(buf));
 
 	if (uname(&buf))
 		tst_brk(TBROK | TERRNO, "Call to uname failed");
 
+	if (!test_nr)
+		memcpy(&saved_buf, &buf, sizeof(saved_buf));
+
 #define CHECK_FIELD(field_name) \
-	(check_field(buf.field_name, ARRAY_SIZE(buf.field_name), #field_name))
+	(check_field(buf.field_name, saved_buf.field_name, \
+		     ARRAY_SIZE(buf.field_name), #field_name))
 
 	if (!(CHECK_FIELD(release) |
 	    CHECK_FIELD(sysname) |
@@ -69,14 +78,14 @@ static void try_leak_bytes(void)
 
 static void run(unsigned int test_nr)
 {
-	if (!test_nr) {
+	if (!test_nr)
 		tst_res(TINFO, "Calling uname with default personality");
-		try_leak_bytes();
-	} else {
+	else {
 		SAFE_PERSONALITY(PER_LINUX | UNAME26);
 		tst_res(TINFO, "Calling uname with UNAME26 personality");
-		try_leak_bytes();
 	}
+
+	try_leak_bytes(test_nr);
 }
 
 static struct tst_test test = {


### PR DESCRIPTION
When uname() is called with UNAME26 personality, the
uname->release field will be filled twise by kernel. If the
length of uname->release initially filled by the normal value
of release is longer at least 2 bytes than the converted, the
test case will fail due to leaking the longer part, e.g,
4.9.65006+ (10-byte) is converted to 2.6.69+ (7-byte), and the
last 2 characters will be leaked and cause a failure of test.

In order to fix this issue, save the normal values returned by
the first call of uname(), and make a compare when checking
against the converted values returned by UNAME26 personality.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>