### PR TITLE
Check vsftpd command before checking the users file

### DIFF
--- a/testcases/network/tcp_cmds/ftp/ftp04
+++ b/testcases/network/tcp_cmds/ftp/ftp04
@@ -32,14 +32,9 @@ setup()
 {
 	TEST_USER=root
 
-	tvar=${MACHTYPE%-*}
-	tvar=${tvar#*-}
+	ftpusers="/etc/ftpusers"
+	[ -f "$ftpusers" ] || ftpusers="/etc/vsftpd/ftpusers"
 
-	if [ $tvar = "redhat" -o $tvar = "redhat-linux" ]; then
-		ftpusers="/etc/vsftpd/ftpusers"
-	else
-		ftpusers="/etc/ftpusers"
-	fi
 	echo "Verifying test user $TEST_USER is in ${ftpusers} database..."
 	FTPUSERS=$(awk "/$TEST_USER/" ${ftpusers})
 	if [ -z "$FTPUSERS" ] ; then
@@ -76,8 +71,8 @@ TST_TOTAL=1
 . test.sh
 . ftp_setup
 
-setup
 do_setup
+setup
 
 do_test
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
As local setup has more priority over the ftp_setup, test breaks with following
<<<test_output>>>
Verifying test user root is in /etc/vsftpd/ftpusers database...
awk: fatal: cannot open file `/etc/vsftpd/ftpusers' for reading (No such file or directory)
ftp04 1 TBROK: root not found in /etc/vsftpd/ftpusers exiting 0 ...

This patch fixes the issue as a check is added prior to checking the users file

Signed-off-by: Harish <harish@linux.vnet.ibm.com>