### PR TITLE
commands/keyctl01.sh: remove bash expression

### DIFF
--- a/testcases/commands/keyctl/keyctl01.sh
+++ b/testcases/commands/keyctl/keyctl01.sh
@@ -113,7 +113,7 @@ do_test()
 			tst_sleep 50ms
 		fi
 
-		((maxkeysz -= 4))
+		maxkeysz=$((maxkeysz - 4))
 	done
 
 	if [ $quota_excd -eq 0 ]; then


### PR DESCRIPTION
While running cve-2016-4470, I received a lot of error text from
keyctl01.sh about "maxkeysz not found". I root-caused this to a
bash-specific expression which is incompatible with the POSIX shell
specification.

This patch makes the expression POSIX shell compliant, and should remove
the script execution error. (It did for me).

Fixes: 05de90daad48 ("commands/keyctl01: Add new regression test")
Signed-off-by: Joe Konno <joe.konno@intel.com>