### PR TITLE
runltp: fix lack of memory space on some low memory embedded system boards

### DIFF
--- a/runltp
+++ b/runltp
@@ -986,8 +986,17 @@ main()
 
 create_block()
 {
+    #default block size is 256MB
+    block_size=262144
+    #set block size as 1/4 size of total memory for small memory system
+    mem_size=$(cat /proc/meminfo | sed -n '1p' | awk -F':' '{print $2}' | awk -F' ' '{print $1}')
+    block_size=$(($mem_size / 4))
+    if [ $block_size -gt 262144 ]; then
+        block_size=262144
+    fi
+
     #create a block device
-    dd if=/dev/zero of=${TMP}/test.img bs=1024 count=262144 >/dev/null 2>&1
+    dd if=/dev/zero of=${TMP}/test.img bs=1024 count=$block_size >/dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Failed to create loopback device image, please check disk space and re-run"
         return 1


### PR DESCRIPTION
The memory size is only 492M on our some dedicated products those can
also run embedded Linux system. If runs LTP suite to validate them, runltp
will use a half of this size, which will lead to lack of memory space
in testing.

Signed-off-by: Zhuo Zhang <zhuo.zhang@nxp.com>