### PR TITLE
cve-2016-10044: use a pointer type for the aio context

### DIFF
--- a/testcases/cve/cve-2016-10044.c
+++ b/testcases/cve/cve-2016-10044.c
@@ -41,7 +41,7 @@ static void cleanup(void)
 
 static void run(void)
 {
-	uint64_t ctx = 0;
+	void* ctx = 0;
 	char perms[8], line[BUFSIZ];
 
 	SAFE_PERSONALITY(READ_IMPLIES_EXEC);


### PR DESCRIPTION
The code was not working on 32-bit ARM systems because we pass a
64-bit integer to the tst_syscall wrapper where in fact a pointer of
size 32 bits is expected. The kernel received zero as the context to
io_destroy.

Signed-off-by: Lars Persson <larper@axis.com>