### PR TITLE
net/ipsec_lib.sh: Don't waste entropy from /dev/urandom

### DIFF
--- a/testcases/network/stress/ipsec/ipsec_lib.sh
+++ b/testcases/network/stress/ipsec/ipsec_lib.sh
@@ -73,8 +73,8 @@ TST_USE_LEGACY_API=1
 get_key()
 {
 	local bits=$1
-	local xdg_num=$(( $bits / 4 ))
-	echo "0x$(tr -dc "[:xdigit:]" < /dev/urandom | head -c$xdg_num)"
+	local bytes=$(( $bits / 8))
+	echo "0x$(hexdump -vn $bytes -e '1/1 "%02x"' /dev/urandom)"
 }
 
 case $AEALGO in


### PR DESCRIPTION
`tr` filters urandom by dropping non-hex symbols which results in
reducing entropy pool faster than needed.
Generate key with with one call to `hexdump` eliminating `head`.
`hexdump` is provided by `util-linux` packages, which also includes
such commands as `swapon`/`mkfs`/`fdisk`/`mount`, so it should be
already installed.

Signed-off-by: Dmitry Safonov <dima@arista.com>