### PR TITLE
shmat() for 0 (or <PAGESIZE with RND flag) has to fail with REMAPs

### DIFF
--- a/testcases/cve/cve-2017-5669.c
+++ b/testcases/cve/cve-2017-5669.c
@@ -28,7 +28,20 @@
  * is just to see if we get an access error or some other unexpected behaviour.
  *
  * See commit 95e91b831f (ipc/shm: Fix shmat mmap nil-page protection)
+ *
+ * The commit above disallowed SHM_RND maps to zero (and rounded) entirely and
+ * that broke userland for cases like Xorg. New behavior disallows REMAPs to
+ * lower addresses (0<=PAGESIZE).
+ *
+ * See commit a73ab244f0da (Revert "ipc/shm: Fix shmat mmap nil-page protect...)
+ * See commit 8f89c007b6de (ipc/shm: fix shmat() nil address after round-dow...)
+ * See https://github.com/linux-test-project/ltp/issues/319
+ *
+ * This test needs root permissions or else security_mmap_addr(), from
+ * get_unmapped_area(), will cause permission errors when trying to mmap lower
+ * addresses.
  */
+
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
@@ -60,7 +73,11 @@ static void cleanup(void)
 static void run(void)
 {
 	tst_res(TINFO, "Attempting to attach shared memory to null page");
-	shm_addr = shmat(shm_id, ((void *)1), SHM_RND);
+	/*
+	 * shmat() for 0 (or < PAGESIZE with RND flag) has to fail with REMAPs
+	 * https://github.com/linux-test-project/ltp/issues/319
+	 */
+	shm_addr = shmat(shm_id, ((void *)1), SHM_RND | SHM_REMAP);
 	if (shm_addr == (void *)-1) {
 		shm_addr = NULL;
 		if (errno == EINVAL) {
@@ -89,6 +106,7 @@ static void run(void)
 }
 
 static struct tst_test test = {
+	.needs_root = 1,
 	.setup = setup,
 	.cleanup = cleanup,
 	.test_all = run,


### PR DESCRIPTION
Fixes: https://github.com/linux-test-project/ltp/issues/319

According to upstream thread (https://lkml.org/lkml/2018/5/28/2056),
cve-2017-5669 needs to address the "new" way of handling nil addresses
for shmat() when used with MAP_FIXED or SHM_REMAP flags.

- mapping nil-page is OK on lower addresses with MAP_FIXED (or else X11 is broken)
- mapping nil-page is NOT OK with SHM_REMAP on lower addresses

Addresses Davidlohr Bueso's comments/changes:

commit 8f89c007b6de
Author: Davidlohr Bueso <dave@stgolabs.net>
Date:   Fri May 25 14:47:30 2018 -0700

    ipc/shm: fix shmat() nil address after round-down when remapping

commit a73ab244f0da
Author: Davidlohr Bueso <dave@stgolabs.net>
Date:   Fri May 25 14:47:27 2018 -0700

    Revert "ipc/shm: Fix shmat mmap nil-page protection"

For previously test made based on:

commit 95e91b831f87
Author: Davidlohr Bueso <dave@stgolabs.net>
Date:   Mon Feb 27 14:28:24 2017 -0800

    ipc/shm: Fix shmat mmap nil-page protection

Signed-off-by: Rafael David Tinoco <rafael.tinoco@linaro.org>