### PR TITLE
fix zram02.sh disksize

### DIFF
--- a/testcases/kernel/device-drivers/zram/zram02.sh
+++ b/testcases/kernel/device-drivers/zram/zram02.sh
@@ -40,7 +40,7 @@ zram_max_streams="2"
 # bytes to make sure everything works correctly.
 # Calculate memory to use for zram (200% of ram)
 totalmem=`LC_ALL=C free | grep -e "^Mem:" | sed -e 's/^Mem: *//' -e 's/  *.*//'`
-zram_sizes=$(((totalmem * 2 / ${dev_num}) * 1024))
+zram_sizes=$(((totalmem * 2 / $dev_num) * 1024))
 zram_mem_limits="1M"
 
 TST_CLEANUP="zram_cleanup"

--- a/testcases/kernel/device-drivers/zram/zram02.sh
+++ b/testcases/kernel/device-drivers/zram/zram02.sh
@@ -39,7 +39,7 @@ zram_max_streams="2"
 # memparse() which supports mem suffixes. So here we just use
 # bytes to make sure everything works correctly.
 # Calculate memory to use for zram (200% of ram)
-totalmem=`free | grep -e "^Mem:" | sed -e 's/^Mem: *//' -e 's/  *.*//'`
+totalmem=``LC_ALL=C free | grep -e "^Mem:" | sed -e 's/^Mem: *//' -e 's/  *.*//'`
 zram_sizes=$(((totalmem * 2 / ${dev_num}) * 1024))
 zram_mem_limits="1M"
 

--- a/testcases/kernel/device-drivers/zram/zram02.sh
+++ b/testcases/kernel/device-drivers/zram/zram02.sh
@@ -38,7 +38,9 @@ zram_max_streams="2"
 # not support mem suffixes, in some newer kernels, they use
 # memparse() which supports mem suffixes. So here we just use
 # bytes to make sure everything works correctly.
-zram_sizes="107374182400" # 100GB
+# Calculate memory to use for zram (200% of ram)
+totalmem=`free | grep -e "^Mem:" | sed -e 's/^Mem: *//' -e 's/  *.*//'`
+zram_sizes=$(((totalmem * 2 / ${dev_num}) * 1024))
 zram_mem_limits="1M"
 
 TST_CLEANUP="zram_cleanup"

--- a/testcases/kernel/device-drivers/zram/zram02.sh
+++ b/testcases/kernel/device-drivers/zram/zram02.sh
@@ -39,7 +39,7 @@ zram_max_streams="2"
 # memparse() which supports mem suffixes. So here we just use
 # bytes to make sure everything works correctly.
 # Calculate memory to use for zram (200% of ram)
-totalmem=``LC_ALL=C free | grep -e "^Mem:" | sed -e 's/^Mem: *//' -e 's/  *.*//'`
+totalmem=`LC_ALL=C free | grep -e "^Mem:" | sed -e 's/^Mem: *//' -e 's/  *.*//'`
 zram_sizes=$(((totalmem * 2 / ${dev_num}) * 1024))
 zram_mem_limits="1M"
 


### PR DESCRIPTION
100GB of disksize maybe too big for some devices, the set disksize should be calculated based on the total memory of the device.

Quote from https://www.kernel.org/doc/Documentation/blockdev/zram.txt:

There is little point creating a zram of greater than twice the size of memory since we expect a 2:1 compression ratio. Note that zram uses about 0.1% of the size of the disk when not in use so a huge zram is wasteful.