### PR TITLE
Make it possible to run some cpuset testcases on none-NUMA machine

### DIFF
--- a/testcases/kernel/controllers/cpuset/cpuset_hotplug_test/cpuset_hotplug_test.sh
+++ b/testcases/kernel/controllers/cpuset/cpuset_hotplug_test/cpuset_hotplug_test.sh
@@ -28,7 +28,7 @@ export TST_COUNT=1
 
 . cpuset_funcs.sh
 
-check
+check 2 1
 
 exit_status=0
 

--- a/testcases/kernel/controllers/cpuset/cpuset_inherit_test/cpuset_inherit_testset.sh
+++ b/testcases/kernel/controllers/cpuset/cpuset_inherit_test/cpuset_inherit_testset.sh
@@ -28,7 +28,7 @@ export TST_COUNT=1
 
 . cpuset_funcs.sh
 
-check
+check 1 1
 
 nr_cpus=$NR_CPUS
 nr_mems=$N_NODES


### PR DESCRIPTION
some cpuset testcase can be run on none-NUMA machine. this patch
change the strict check.

Signed-off-by: Wang Long <w@laoqinren.net>