### PR TITLE
Fix linking inotify09 on older systems

### DIFF
--- a/testcases/kernel/syscalls/inotify/Makefile
+++ b/testcases/kernel/syscalls/inotify/Makefile
@@ -20,5 +20,5 @@ top_srcdir		?= ../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 inotify09: CFLAGS+=-pthread
-inotify09: LDFLAGS+=-lrt
+inotify09: LDLIBS+=-lrt
 include $(top_srcdir)/include/mk/generic_leaf_target.mk


### PR DESCRIPTION
We fix the build system for inotify syscall tests to use LDLIBS rather
than LDFLAGS to provide the rt library. This prevented the project
from linking correctly under Ubuntu 12.04, which failed with
"undefined reference to 'clock_gettime'".