### PR TITLE
syscalls/fsetxattr: Add fsetxattr() tests based on setxattr() ones

### DIFF
--- a/include/tst_safe_macros.h
+++ b/include/tst_safe_macros.h
@@ -461,6 +461,16 @@ int safe_removexattr(const char *file, const int lineno, const char *path,
 #define SAFE_REMOVEXATTR(path, name) \
 	safe_removexattr(__FILE__, __LINE__, (path), (name))
 
+int safe_lremovexattr(const char *file, const int lineno, const char *path,
+		const char *name);
+#define SAFE_LREMOVEXATTR(path, name) \
+	safe_lremovexattr(__FILE__, __LINE__, (path), (name))
+
+int safe_fremovexattr(const char *file, const int lineno, int fd,
+		const char *name);
+#define SAFE_FREMOVEXATTR(fd, name) \
+	safe_fremovexattr(__FILE__, __LINE__, (fd), (name))
+
 int safe_fsync(const char *file, const int lineno, int fd);
 #define SAFE_FSYNC(fd) safe_fsync(__FILE__, __LINE__, (fd))
 

--- a/lib/safe_macros.c
+++ b/lib/safe_macros.c
@@ -924,6 +924,48 @@ int safe_removexattr(const char *file, const int lineno, const char *path,
 	return rval;
 }
 
+int safe_lremovexattr(const char *file, const int lineno, const char *path,
+		const char *name)
+{
+	int rval;
+
+	rval = lremovexattr(path, name);
+
+	if (rval) {
+		if (errno == ENOTSUP) {
+			tst_brkm(TCONF, NULL,
+				"%s:%d: no xattr support in fs or mounted "
+				"without user_xattr option", file, lineno);
+		}
+
+		tst_brkm(TBROK | TERRNO, NULL, "%s:%d: lremovexattr() failed",
+			file, lineno);
+	}
+
+	return rval;
+}
+
+int safe_fremovexattr(const char *file, const int lineno, int fd,
+		const char *name)
+{
+	int rval;
+
+	rval = fremovexattr(fd, name);
+
+	if (rval) {
+		if (errno == ENOTSUP) {
+			tst_brkm(TCONF, NULL,
+				"%s:%d: no xattr support in fs or mounted "
+				"without user_xattr option", file, lineno);
+		}
+
+		tst_brkm(TBROK | TERRNO, NULL, "%s:%d: fremovexattr() failed",
+			file, lineno);
+	}
+
+	return rval;
+}
+
 int safe_fsync(const char *file, const int lineno, int fd)
 {
 	int rval;

--- a/runtest/syscalls
+++ b/runtest/syscalls
@@ -163,6 +163,9 @@ fallocate03 fallocate03
 fallocate04 fallocate04
 fallocate05 fallocate05
 
+fsetxattr01 fsetxattr01
+fsetxattr02 fsetxattr02
+
 #posix_fadvise test cases
 posix_fadvise01                      posix_fadvise01
 posix_fadvise01_64                posix_fadvise01_64

--- a/runtest/syscalls
+++ b/runtest/syscalls
@@ -281,6 +281,10 @@ fcntl36_64 fcntl36_64
 fdatasync01 fdatasync01
 fdatasync02 fdatasync02
 
+fgetxattr01 fgetxattr01
+fgetxattr02 fgetxattr02
+fgetxattr03 fgetxattr03
+
 flistxattr01 flistxattr01
 flistxattr02 flistxattr02
 flistxattr03 flistxattr03

--- a/testcases/kernel/syscalls/fgetxattr/.gitignore
+++ b/testcases/kernel/syscalls/fgetxattr/.gitignore
@@ -1,0 +1,3 @@
+/fgetxattr01
+/fgetxattr02
+/fgetxattr03

--- a/testcases/kernel/syscalls/fgetxattr/Makefile
+++ b/testcases/kernel/syscalls/fgetxattr/Makefile
@@ -1,0 +1,8 @@
+# Copyright (c) 2018 - Linaro Limited. All rights reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+top_srcdir		?= ../../../..
+
+include $(top_srcdir)/include/mk/testcases.mk
+
+include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/fgetxattr/fgetxattr01.c
+++ b/testcases/kernel/syscalls/fgetxattr/fgetxattr01.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2018 Linaro Limited. All rights reserved.
+ * Author: Rafael David Tinoco <rafael.tinoco@linaro.org>
+ */
+
+/*
+ * Basic tests for fgetxattr(2) and make sure fgetxattr(2) handles error
+ * conditions correctly.
+ *
+ * There are 3 test cases:
+ * 1. Get an non-existing attribute:
+ *     - fgetxattr(2) should return -1 and set errno to ENODATA
+ * 2. Buffer size is smaller than attribute value size:
+ *     - fgetxattr(2) should return -1 and set errno to ERANGE
+ * 3. Get attribute, fgetxattr(2) should succeed:
+ *     - verify the attribute got by fgetxattr(2) is same as the value we set
+ */
+
+#include "config.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_SYS_XATTR_H
+# include <sys/xattr.h>
+#endif
+#include "tst_test.h"
+
+#ifdef HAVE_SYS_XATTR_H
+#define XATTR_SIZE_MAX 65536
+#define XATTR_TEST_KEY "user.testkey"
+#define XATTR_TEST_VALUE "this is a test value"
+#define XATTR_TEST_VALUE_SIZE 20
+#define XATTR_TEST_INVALID_KEY "user.nosuchkey"
+#define MNTPOINT "mntpoint"
+#define FNAME MNTPOINT"/fgetxattr01testfile"
+
+static int fd = -1;
+
+struct test_case {
+	char *key;
+	char *value;
+	size_t size;
+	int exp_ret;
+	int exp_err;
+};
+struct test_case tc[] = {
+	{			/* case 00, get non-existing attribute */
+	 .key = XATTR_TEST_INVALID_KEY,
+	 .value = NULL,
+	 .size = XATTR_SIZE_MAX,
+	 .exp_ret = -1,
+	 .exp_err = ENODATA,
+	 },
+	{			/* case 01, small value buffer */
+	 .key = XATTR_TEST_KEY,
+	 .value = NULL,
+	 .size = 1,
+	 .exp_ret = -1,
+	 .exp_err = ERANGE,
+	 },
+	{			/* case 02, get existing attribute */
+	 .key = XATTR_TEST_KEY,
+	 .value = NULL,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .exp_ret = XATTR_TEST_VALUE_SIZE,
+	 .exp_err = 0,
+	 },
+};
+
+static void verify_fgetxattr(unsigned int i)
+{
+	TEST(fgetxattr(fd, tc[i].key, tc[i].value, tc[i].size));
+
+	if (TST_RET == -1 && TST_ERR == EOPNOTSUPP)
+		tst_brk(TCONF, "fgetxattr(2) not supported");
+
+	if (TST_RET >= 0) {
+
+		if (tc[i].exp_ret == TST_RET)
+			tst_res(TPASS, "fgetxattr(2) passed");
+		else
+			tst_res(TFAIL, "fgetxattr(2) passed unexpectedly");
+
+		if (strncmp(tc[i].value, XATTR_TEST_VALUE,
+				XATTR_TEST_VALUE_SIZE)) {
+			tst_res(TFAIL, "wrong value, expect \"%s\" got \"%s\"",
+					 XATTR_TEST_VALUE, tc[i].value);
+		}
+
+		tst_res(TPASS, "got the right value");
+	}
+
+	if (tc[i].exp_err == TST_ERR) {
+		tst_res(TPASS | TTERRNO, "fgetxattr(2) passed");
+		return;
+	}
+
+	tst_res(TFAIL | TTERRNO, "fgetxattr(2) failed");
+}
+
+static void setup(void)
+{
+	size_t i = 0;
+
+	SAFE_TOUCH(FNAME, 0644, NULL);
+	fd = SAFE_OPEN(FNAME, O_RDONLY, NULL);
+
+	for (i = 0; i < ARRAY_SIZE(tc); i++) {
+		tc[i].value = SAFE_MALLOC(tc[i].size);
+		memset(tc[i].value, 0, tc[i].size);
+	}
+
+	SAFE_FSETXATTR(fd, XATTR_TEST_KEY, XATTR_TEST_VALUE,
+			XATTR_TEST_VALUE_SIZE, XATTR_CREATE);
+}
+
+static void cleanup(void)
+{
+	size_t i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(tc); i++)
+		free(tc[i].value);
+
+	if (fd > 0)
+		SAFE_CLOSE(fd);
+}
+
+static struct tst_test test = {
+	.setup = setup,
+	.test = verify_fgetxattr,
+	.cleanup = cleanup,
+	.tcnt = ARRAY_SIZE(tc),
+	.mntpoint = MNTPOINT,
+	.mount_device = 1,
+	.all_filesystems = 1,
+	.needs_tmpdir = 1,
+	.needs_root = 1,	/* root: check all supported filesystems */
+};
+
+#else /* HAVE_SYS_XATTR_H */
+TST_TEST_TCONF("<sys/xattr.h> does not exist");
+#endif

--- a/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c
+++ b/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2018 Linaro Limited. All rights reserved.
+ * Author: Rafael David Tinoco <rafael.tinoco@linaro.org>
+ */
+
+/*
+ * In the user.* namespace, only regular files and directories can
+ * have extended attributes. Otherwise fgetxattr(2) will return -1
+ * and set proper errno.
+ *
+ * There are 7 test cases:
+ *
+ * 1. Get attribute from a regular file:
+ *    - fgetxattr(2) should succeed
+ *    - checks returned value to be the same as we set
+ * 2. Get attribute from a directory:
+ *    - fgetxattr(2) should succeed
+ *    - checks returned value to be the same as we set
+ * 3. Get attribute from a symlink which points to the regular file:
+ *    - fgetxattr(2) should succeed
+ *    - checks returned value to be the same as we set
+ * 4. Get attribute from a FIFO:
+ *    - fgetxattr(2) should return -1 and set errno to ENODATA
+ * 5. Get attribute from a char special file:
+ *    - fgetxattr(2) should return -1 and set errno to ENODATA
+ * 6. Get attribute from a block special file:
+ *    - fgetxattr(2) should return -1 and set errno to ENODATA
+ * 7. Get attribute from a UNIX domain socket:
+ *    - fgetxattr(2) should return -1 and set errno to ENODATA
+ */
+
+#include "config.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#ifdef HAVE_SYS_XATTR_H
+# include <sys/xattr.h>
+#endif
+#include "tst_test.h"
+
+#ifdef HAVE_SYS_XATTR_H
+#define XATTR_TEST_KEY "user.testkey"
+#define XATTR_TEST_VALUE "this is a test value"
+#define XATTR_TEST_VALUE_SIZE 20
+
+#define OFFSET    11
+#define FILENAME "fgetxattr02testfile"
+#define DIRNAME  "fgetxattr02testdir"
+#define SYMLINK  "fgetxattr02symlink"
+#define SYMLINKF "fgetxattr02symlinkfile"
+#define FIFO     "fgetxattr02fifo"
+#define CHR      "fgetxattr02chr"
+#define BLK      "fgetxattr02blk"
+#define SOCK     "fgetxattr02sock"
+
+struct test_case {
+	char *fname;
+	int fd;
+	int fflags;
+	char *key;
+	char *value;
+	size_t size;
+	char *ret_value;
+	int flags;
+	int exp_err;
+	int exp_ret;
+	int issocket;
+};
+static struct test_case tc[] = {
+	{			/* case 00, get attr from reg */
+	 .fname = FILENAME,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .ret_value = NULL,
+	 .flags = XATTR_CREATE,
+	 .exp_err = 0,
+	 .exp_ret = XATTR_TEST_VALUE_SIZE,
+	 },
+	{			/* case 01, get attr from dir */
+	 .fname = DIRNAME,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .ret_value = NULL,
+	 .flags = XATTR_CREATE,
+	 .exp_err = 0,
+	 .exp_ret = XATTR_TEST_VALUE_SIZE,
+	 },
+	{			/* case 02, get attr from symlink */
+	 .fname = SYMLINK,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .ret_value = NULL,
+	 .flags = XATTR_CREATE,
+	 .exp_err = 0,
+	 .exp_ret = XATTR_TEST_VALUE_SIZE,
+	 },
+	{			/* case 03, get attr from fifo */
+	 .fname = FIFO,
+	 .fflags = (O_RDONLY | O_NONBLOCK),
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = ENODATA,
+	 .exp_ret = -1,
+	 },
+	{			/* case 04, get attr from character special */
+	 .fname = CHR,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .ret_value = NULL,
+	 .flags = XATTR_CREATE,
+	 .exp_err = ENODATA,
+	 .exp_ret = -1,
+	 },
+	{			/* case 05, get attr from block special */
+	 .fname = BLK,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .ret_value = NULL,
+	 .flags = XATTR_CREATE,
+	 .exp_err = ENODATA,
+	 .exp_ret = -1,
+	 },
+	{			/* case 06, get attr from socket */
+	 .fname = SOCK,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .ret_value = NULL,
+	 .flags = XATTR_CREATE,
+	 .exp_err = ENODATA,
+	 .exp_ret = -1,
+	 .issocket = 1,
+	 },
+};
+
+static void verify_fgetxattr(unsigned int i)
+{
+	TEST(fgetxattr(tc[i].fd, tc[i].key, tc[i].ret_value, tc[i].size));
+
+	if (TST_RET == -1 && TST_ERR == EOPNOTSUPP)
+		tst_brk(TCONF, "fgetxattr(2) not supported");
+
+	if (TST_RET >= 0) {
+
+		if (tc[i].exp_ret == TST_RET) {
+			tst_res(TPASS, "fgetxattr(2) on %s passed",
+					tc[i].fname + OFFSET);
+		} else {
+			tst_res(TFAIL,
+				"fgetxattr(2) on %s passed unexpectedly %ld",
+				tc[i].fname + OFFSET, TST_RET);
+		}
+
+		if (strncmp(tc[i].ret_value, XATTR_TEST_VALUE,
+				XATTR_TEST_VALUE_SIZE)) {
+			tst_res(TFAIL, "wrong value, expect \"%s\" got \"%s\"",
+					 XATTR_TEST_VALUE, tc[i].ret_value);
+		}
+
+		tst_res(TPASS, "fgetxattr(2) on %s got the right value",
+				tc[i].fname + OFFSET);
+	}
+
+	if (tc[i].exp_err == TST_ERR) {
+		tst_res(TPASS | TTERRNO, "fgetxattr(2) on %s passed",
+				tc[i].fname + OFFSET);
+		return;
+	}
+
+	tst_res(TFAIL | TTERRNO, "fgetxattr(2) failed on %s",
+			tc[i].fname + OFFSET);
+}
+
+static void setup(void)
+{
+	size_t i = 0;
+	struct sockaddr_un sun;
+
+	dev_t dev = makedev(1, 3);
+
+	SAFE_TOUCH(FILENAME, 0644, NULL);
+	SAFE_TOUCH(SYMLINKF, 0644, NULL);
+	SAFE_MKDIR(DIRNAME, 0644);
+	SAFE_SYMLINK(SYMLINKF, SYMLINK);
+
+	/* root: mknod(2) needs it to create something other than a file */
+	SAFE_MKNOD(FIFO, S_IFIFO | 0777, 0);
+	SAFE_MKNOD(CHR, S_IFCHR | 0777, dev);
+	SAFE_MKNOD(BLK, S_IFBLK | 0777, dev);
+
+	for (i = 0; i < ARRAY_SIZE(tc); i++) {
+
+		tc[i].ret_value = SAFE_MALLOC(tc[i].size);
+		memset(tc[i].ret_value, 0, tc[i].size);
+
+		if (tc[i].issocket) {
+			/* differently than getxattr(2) calls, when dealing with
+			 * sockets, mknod(2) isn't enough to test fgetxattr(2).
+			 * we have to get a real unix socket in order for
+			 * open(2) to get a file desc.
+			 */
+			tc[i].fd = SAFE_SOCKET(AF_UNIX, SOCK_STREAM, 0);
+
+			memset(&sun, 0, sizeof(struct sockaddr_un));
+			sun.sun_family = AF_UNIX;
+			strncpy(sun.sun_path, tc[i].fname,
+					sizeof(sun.sun_path) - 1);
+
+			SAFE_BIND(tc[i].fd, (const struct sockaddr *) &sun,
+					sizeof(struct sockaddr_un));
+		} else {
+			tc[i].fd = SAFE_OPEN(tc[i].fname, tc[i].fflags, NULL);
+		}
+
+		if (tc[i].exp_ret >= 0) {
+			SAFE_FSETXATTR(tc[i].fd, tc[i].key, tc[i].value,
+					tc[i].size, tc[i].flags);
+		}
+	}
+}
+
+static void cleanup(void)
+{
+	size_t i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(tc); i++) {
+		free(tc[i].ret_value);
+
+		if (tc[i].fd > 0)
+			SAFE_CLOSE(tc[i].fd);
+	}
+}
+
+static struct tst_test test = {
+	.setup = setup,
+	.test = verify_fgetxattr,
+	.cleanup = cleanup,
+	.tcnt = ARRAY_SIZE(tc),
+	.needs_tmpdir = 1,
+	.needs_root = 1,
+};
+
+#else /* HAVE_SYS_XATTR_H */
+TST_TEST_TCONF("<sys/xattr.h> does not exist");
+#endif

--- a/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
+++ b/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2018 Linaro Limited. All rights reserved.
+ * Author: Rafael David Tinoco <rafael.tinoco@linaro.org>
+ */
+
+/*
+ * An empty buffer of size zero can be passed into fgetxattr(2) to return
+ * the current size of the named extended attribute.
+ */
+
+#include "config.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_SYS_XATTR_H
+# include <sys/xattr.h>
+#endif
+#include "tst_test.h"
+
+#ifdef HAVE_SYS_XATTR_H
+#define XATTR_TEST_KEY "user.testkey"
+#define XATTR_TEST_VALUE "this is a test value"
+#define XATTR_TEST_VALUE_SIZE 20
+#define FILENAME "fgetxattr03testfile"
+
+static int fd = -1;
+
+static void verify_fgetxattr(void)
+{
+	TEST(fgetxattr(fd, XATTR_TEST_KEY, NULL, 0));
+
+	if (TST_RET == XATTR_TEST_VALUE_SIZE) {
+		tst_res(TPASS, "fgetxattr(2) returned correct value");
+		return;
+	}
+
+	tst_res(TFAIL | TTERRNO, "fgetxattr(2) failed");
+}
+
+static void setup(void)
+{
+	SAFE_TOUCH(FILENAME, 0644, NULL);
+	fd = SAFE_OPEN(FILENAME, O_RDONLY, NULL);
+
+	SAFE_FSETXATTR(fd, XATTR_TEST_KEY, XATTR_TEST_VALUE,
+			XATTR_TEST_VALUE_SIZE, XATTR_CREATE);
+}
+
+static void cleanup(void)
+{
+	if (fd > 0)
+		SAFE_CLOSE(fd);
+}
+
+static struct tst_test test = {
+	.setup = setup,
+	.test_all = verify_fgetxattr,
+	.cleanup = cleanup,
+	.needs_tmpdir = 1,
+};
+
+#else /* HAVE_SYS_XATTR_H */
+TST_TEST_TCONF("<sys/xattr.h> does not exist");
+#endif
+

--- a/testcases/kernel/syscalls/fsetxattr/.gitignore
+++ b/testcases/kernel/syscalls/fsetxattr/.gitignore
@@ -1,0 +1,2 @@
+/fsetxattr01
+/fsetxattr02

--- a/testcases/kernel/syscalls/fsetxattr/Makefile
+++ b/testcases/kernel/syscalls/fsetxattr/Makefile
@@ -1,0 +1,8 @@
+# Copyright (c) 2018 - Linaro Limited. All rights reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+top_srcdir		?= ../../../..
+
+include $(top_srcdir)/include/mk/testcases.mk
+
+include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/testcases/kernel/syscalls/fsetxattr/fsetxattr01.c
+++ b/testcases/kernel/syscalls/fsetxattr/fsetxattr01.c
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2018 Linaro Limited. All rights reserved.
+ * Author: Rafael David Tinoco <rafael.tinoco@linaro.org>
+ */
+
+/*
+ * Basic tests for fsetxattr(2) and make sure fsetxattr(2) handles error
+ * conditions correctly.
+ *
+ * There are 9 test cases:
+ * 1. Any other flags being set except XATTR_CREATE and XATTR_REPLACE,
+ *    fsetxattr(2) should return -1 and set errno to EINVAL
+ * 2. With XATTR_REPLACE flag set but the attribute does not exist,
+ *    fsetxattr(2) should return -1 and set errno to ENODATA
+ * 3. Create new attr with name length greater than XATTR_NAME_MAX(255)
+ *    fsetxattr(2) should return -1 and set errno to ERANGE
+ * 4. Create new attr whose value length is greater than XATTR_SIZE_MAX(65536)
+ *    fsetxattr(2) should return -1 and set errno to E2BIG
+ * 5. Create new attr whose value length is zero,
+ *    fsetxattr(2) should succeed
+ * 6. Replace the attr value without XATTR_REPLACE flag being set,
+ *    fsetxattr(2) should return -1 and set errno to EEXIST
+ * 7. Replace attr value with XATTR_REPLACE flag being set,
+ *    fsetxattr(2) should succeed
+ * 8. Create new attr whose key length is zero,
+ *    fsetxattr(2) should return -1 and set errno to ERANGE
+ * 9. Create new attr whose key is NULL,
+ *    fsetxattr(2) should return -1 and set errno to EFAULT
+ */
+
+#include "config.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_SYS_XATTR_H
+# include <sys/xattr.h>
+#endif
+#include "tst_test.h"
+
+#ifdef HAVE_SYS_XATTR_H
+#define XATTR_NAME_MAX 255
+#define XATTR_NAME_LEN (XATTR_NAME_MAX + 2)
+#define XATTR_SIZE_MAX 65536
+#define XATTR_TEST_KEY "user.testkey"
+#define XATTR_TEST_VALUE "this is a test value"
+#define XATTR_TEST_VALUE_SIZE 20
+#define MNTPOINT "mntpoint"
+#define FNAME MNTPOINT"/fsetxattr01testfile"
+
+static int fd = -1;
+static char long_key[XATTR_NAME_LEN];
+static char *long_value;
+static char *xattr_value = XATTR_TEST_VALUE;
+
+struct test_case {
+	char *key;
+	char **value;
+	size_t size;
+	int flags;
+	int exp_err;
+	int keyneeded;
+};
+
+struct test_case tc[] = {
+	{			/* case 00, invalid flags */
+	 .key = XATTR_TEST_KEY,
+	 .value = &xattr_value,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = ~0,
+	 .exp_err = EINVAL,
+	 },
+	{			/* case 01, replace non-existing attribute */
+	 .key = XATTR_TEST_KEY,
+	 .value = &xattr_value,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_REPLACE,
+	 .exp_err = ENODATA,
+	 },
+	{			/* case 02, long key name */
+	 .key = long_key,
+	 .value = &xattr_value,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = ERANGE,
+	 },
+	{			/* case 03, long value */
+	 .key = XATTR_TEST_KEY,
+	 .value = &long_value,
+	 .size = XATTR_SIZE_MAX + 1,
+	 .flags = XATTR_CREATE,
+	 .exp_err = E2BIG,
+	 },
+	{			/* case 04, zero length value */
+	 .key = XATTR_TEST_KEY,
+	 .value = &xattr_value,
+	 .size = 0,
+	 .flags = XATTR_CREATE,
+	 .exp_err = 0,
+	 },
+	{			/* case 05, create existing attribute */
+	 .key = XATTR_TEST_KEY,
+	 .value = &xattr_value,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = EEXIST,
+	 .keyneeded = 1,
+	 },
+	{			/* case 06, replace existing attribute */
+	 .key = XATTR_TEST_KEY,
+	 .value = &xattr_value,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_REPLACE,
+	 .exp_err = 0,
+	 .keyneeded = 1,
+	},
+	{			/* case 07, zero length key */
+	 .key = "",
+	 .value = &xattr_value,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = ERANGE,
+	},
+	{			/* case 08, NULL key */
+	 .value = &xattr_value,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = EFAULT,
+	},
+};
+
+static void verify_fsetxattr(unsigned int i)
+{
+	/* some tests might require existing keys for each iteration */
+	if (tc[i].keyneeded) {
+		SAFE_FSETXATTR(fd, tc[i].key, tc[i].value, tc[i].size,
+				XATTR_CREATE);
+	}
+
+	TEST(fsetxattr(fd, tc[i].key, *tc[i].value, tc[i].size, tc[i].flags));
+
+	if (TST_RET == -1 && TST_ERR == EOPNOTSUPP)
+		tst_brk(TCONF, "fsetxattr(2) not supported");
+
+	/* success */
+
+	if (!tc[i].exp_err) {
+		if (TST_RET) {
+			tst_res(TFAIL | TTERRNO,
+				"fsetxattr(2) failed with %li", TST_RET);
+			return;
+		}
+
+		/* this is needed for subsequent iterations */
+		SAFE_FREMOVEXATTR(fd, tc[i].key);
+
+		tst_res(TPASS, "fsetxattr(2) passed");
+
+		return;
+	}
+
+	if (TST_RET == 0) {
+		tst_res(TFAIL, "fsetxattr(2) passed unexpectedly");
+		return;
+	}
+
+	/* error */
+
+	if (tc[i].exp_err != TST_ERR) {
+		tst_res(TFAIL | TTERRNO, "fsetxattr(2) should fail with %s",
+			tst_strerrno(tc[i].exp_err));
+		return;
+	}
+
+	/* key might have been added AND test might have failed, remove it */
+	if (tc[i].keyneeded)
+		SAFE_FREMOVEXATTR(fd, tc[i].key);
+
+	tst_res(TPASS | TTERRNO, "fsetxattr(2) failed");
+}
+
+static void cleanup(void)
+{
+	if (fd > 0)
+		SAFE_CLOSE(fd);
+}
+
+static void setup(void)
+{
+	size_t i = 0;
+
+	snprintf(long_key, 6, "%s", "user.");
+	memset(long_key + 5, 'k', XATTR_NAME_LEN - 5);
+	long_key[XATTR_NAME_LEN - 1] = '\0';
+
+	long_value = SAFE_MALLOC(XATTR_SIZE_MAX + 2);
+	memset(long_value, 'v', XATTR_SIZE_MAX + 2);
+	long_value[XATTR_SIZE_MAX + 1] = '\0';
+
+	SAFE_TOUCH(FNAME, 0644, NULL);
+	fd = SAFE_OPEN(FNAME, O_RDONLY, NULL);
+
+	for (i = 0; i < ARRAY_SIZE(tc); i++) {
+		if (!tc[i].key)
+			tc[i].key = tst_get_bad_addr(cleanup);
+	}
+}
+
+static struct tst_test test = {
+	.setup = setup,
+	.test = verify_fsetxattr,
+	.cleanup = cleanup,
+	.tcnt = ARRAY_SIZE(tc),
+	.mntpoint = MNTPOINT,
+	.mount_device = 1,
+	.all_filesystems = 1,
+	.needs_tmpdir = 1,
+	.needs_root = 1,	/* root: check all supported filesystems */
+};
+
+#else /* HAVE_SYS_XATTR_H */
+TST_TEST_TCONF("<sys/xattr.h> does not exist");
+#endif

--- a/testcases/kernel/syscalls/fsetxattr/fsetxattr02.c
+++ b/testcases/kernel/syscalls/fsetxattr/fsetxattr02.c
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2018 Linaro Limited. All rights reserved.
+ * Author: Rafael David Tinoco <rafael.tinoco@linaro.org>
+ */
+
+/*
+ * In the user.* namespace, only regular files and directories can
+ * have extended attributes. Otherwise fsetxattr(2) will return -1
+ * and set errno to EPERM.
+ *
+ * There are 7 test cases:
+ * 1. Set attribute to a regular file, fsetxattr(2) should succeed
+ * 2. Set attribute to a directory, fsetxattr(2) should succeed
+ * 3. Set attribute to a symlink which points to the regular file,
+ *    fsetxattr(2) should return -1 and set errno to EEXIST
+ * 4. Set attribute to a FIFO, fsetxattr(2) should return -1 and set
+ *    errno to EPERM
+ * 5. Set attribute to a char special file, fsetxattr(2) should
+ *    return -1 and set errno to EPERM
+ * 6. Set attribute to a block special file, fsetxattr(2) should
+ *    return -1 and set errno to EPERM
+ * 7. Set attribute to a UNIX domain socket, fsetxattr(2) should
+ *    return -1 and set errno to EPERM
+ */
+
+#include "config.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#ifdef HAVE_SYS_XATTR_H
+# include <sys/xattr.h>
+#endif
+#include "tst_test.h"
+
+#ifdef HAVE_SYS_XATTR_H
+#define XATTR_TEST_KEY "user.testkey"
+#define XATTR_TEST_VALUE "this is a test value"
+#define XATTR_TEST_VALUE_SIZE 20
+
+#define OFFSET    11
+#define FILENAME "fsetxattr02testfile"
+#define DIRNAME  "fsetxattr02testdir"
+#define SYMLINK  "fsetxattr02symlink"
+#define FIFO     "fsetxattr02fifo"
+#define CHR      "fsetxattr02chr"
+#define BLK      "fsetxattr02blk"
+#define SOCK     "fsetxattr02sock"
+
+struct test_case {
+	char *fname;
+	int fd;
+	int fflags;
+	char *key;
+	char *value;
+	size_t size;
+	int flags;
+	int exp_err;
+	int issocket;
+	int needskeyset;
+};
+static struct test_case tc[] = {
+	{			/* case 00, set attr to reg */
+	 .fname = FILENAME,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = 0,
+	 },
+	{			/* case 01, set attr to dir */
+	 .fname = DIRNAME,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = 0,
+	 },
+	{			/* case 02, set attr to symlink */
+	 .fname = SYMLINK,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = EEXIST,
+	 .needskeyset = 1,
+	 },
+	{			/* case 03, set attr to fifo */
+	 .fname = FIFO,
+	 .fflags = (O_RDONLY | O_NONBLOCK),
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = EPERM,
+	 },
+	{			/* case 04, set attr to character special */
+	 .fname = CHR,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = EPERM,
+	 },
+	{			/* case 05, set attr to block special */
+	 .fname = BLK,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = EPERM,
+	 },
+	{			/* case 06, set attr to socket */
+	 .fname = SOCK,
+	 .fflags = O_RDONLY,
+	 .key = XATTR_TEST_KEY,
+	 .value = XATTR_TEST_VALUE,
+	 .size = XATTR_TEST_VALUE_SIZE,
+	 .flags = XATTR_CREATE,
+	 .exp_err = EPERM,
+	 .issocket = 1,
+	 },
+};
+
+static void verify_fsetxattr(unsigned int i)
+{
+	/* some tests might require existing keys for each iteration */
+	if (tc[i].needskeyset) {
+		SAFE_FSETXATTR(tc[i].fd, tc[i].key, tc[i].value, tc[i].size,
+				XATTR_CREATE);
+	}
+
+	TEST(fsetxattr(tc[i].fd, tc[i].key, tc[i].value, tc[i].size,
+			tc[i].flags));
+
+	if (TST_RET == -1 && TST_ERR == EOPNOTSUPP)
+		tst_brk(TCONF, "fsetxattr(2) not supported");
+
+	/* success */
+
+	if (!tc[i].exp_err) {
+		if (TST_RET) {
+			tst_res(TFAIL | TTERRNO,
+				"fsetxattr(2) on %s failed with %li",
+				tc[i].fname + OFFSET, TST_RET);
+			return;
+		}
+
+		/* this is needed for subsequent iterations */
+		SAFE_FREMOVEXATTR(tc[i].fd, tc[i].key);
+
+		tst_res(TPASS, "fsetxattr(2) on %s passed",
+				tc[i].fname + OFFSET);
+		return;
+	}
+
+	if (TST_RET == 0) {
+		tst_res(TFAIL, "fsetxattr(2) on %s passed unexpectedly",
+				tc[i].fname + OFFSET);
+		return;
+	}
+
+	/* fail */
+
+	if (tc[i].exp_err != TST_ERR) {
+		tst_res(TFAIL | TTERRNO,
+				"fsetxattr(2) on %s should have failed with %s",
+				tc[i].fname + OFFSET,
+				tst_strerrno(tc[i].exp_err));
+		return;
+	}
+
+	/* key might have been added AND test might have failed, remove it */
+	if (tc[i].needskeyset)
+		SAFE_FREMOVEXATTR(tc[i].fd, tc[i].key);
+
+	tst_res(TPASS | TTERRNO, "fsetxattr(2) on %s failed",
+			tc[i].fname + OFFSET);
+}
+
+static void setup(void)
+{
+	size_t i = 0;
+	struct sockaddr_un sun;
+
+	dev_t dev = makedev(1, 3);
+
+	SAFE_TOUCH(FILENAME, 0644, NULL);
+	SAFE_MKDIR(DIRNAME, 0644);
+	SAFE_SYMLINK(FILENAME, SYMLINK);
+
+	/* root: mknod(2) needs it to create something other than a file */
+	SAFE_MKNOD(FIFO, S_IFIFO | 0777, 0);
+	SAFE_MKNOD(CHR, S_IFCHR | 0777, dev);
+	SAFE_MKNOD(BLK, S_IFBLK | 0777, dev);
+
+	for (i = 0; i < ARRAY_SIZE(tc); i++) {
+
+		if (!tc[i].issocket) {
+			tc[i].fd = SAFE_OPEN(tc[i].fname, tc[i].fflags, NULL);
+			continue;
+		}
+
+		/* differently than setxattr calls, when dealing with
+		 * sockets, mknod() isn't enough to test fsetxattr(2).
+		 * we have to get a real unix socket in order for open()
+		 * to get a file desc.
+		 */
+		tc[i].fd = SAFE_SOCKET(AF_UNIX, SOCK_STREAM, 0);
+
+		memset(&sun, 0, sizeof(struct sockaddr_un));
+		sun.sun_family = AF_UNIX;
+		strncpy(sun.sun_path, tc[i].fname, sizeof(sun.sun_path) - 1);
+
+		SAFE_BIND(tc[i].fd, (const struct sockaddr *) &sun,
+				sizeof(struct sockaddr_un));
+	}
+}
+
+static void cleanup(void)
+{
+	size_t i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(tc); i++) {
+		if (tc[i].fd > 0)
+			SAFE_CLOSE(tc[i].fd);
+	}
+}
+
+static struct tst_test test = {
+	.setup = setup,
+	.test = verify_fsetxattr,
+	.cleanup = cleanup,
+	.tcnt = ARRAY_SIZE(tc),
+	.needs_tmpdir = 1,
+	.needs_root = 1,
+};
+
+#else /* HAVE_SYS_XATTR_H */
+TST_TEST_TCONF("<sys/xattr.h> does not exist");
+#endif


### PR DESCRIPTION
Fixes: #274

Following the same logic and tests used to test setxattr() syscalls,
this commit implements tests for fsetxattr(). It only differs from
setxattr() on the given arguments: using a file descriptor instead of
the filename.

Kernel has different entry points for both, with slightly different
execution paths, mainly related to dealing with the passed file
descriptor. Minor changes were made in order for the file descriptors
to be available for the fsetxattr() call.

Signed-off-by: Rafael David Tinoco <rafael.tinoco@linaro.org>