### PR TITLE
Fix typos in README for kdump

### DIFF
--- a/testcases/kdump/README
+++ b/testcases/kdump/README
@@ -87,4 +87,4 @@ period of the test run.
 
 * System may hang if incorrect partition information is provided for
 dumping, like specifying a partition which does not exist, specifying a
-parition label which does not exist. This is not ltp kdump bug.
+partition label which does not exist. This is not ltp kdump bug.

--- a/testcases/kdump/README
+++ b/testcases/kdump/README
@@ -82,7 +82,7 @@ directory shows where you are in the test run. When the "Test run
 complete" entry appears in that file, you're done. Verbose log can be
 found at /tmp/kdump-<date>.log.
 
-* The test machine would be unavailabe for any other work during the
+* The test machine would be unavailable for any other work during the
 period of the test run.
 
 * System may hang if incorrect partition information is provided for

--- a/testcases/kdump/doc/README
+++ b/testcases/kdump/doc/README
@@ -87,4 +87,4 @@ period of the test run.
 
 * System may hang if incorrect partition information is provided for
 dumping, like specifying a partition which does not exist, specifying a
-parition label which does not exist. This is not ltp kdump bug.
+partition label which does not exist. This is not ltp kdump bug.

--- a/testcases/kdump/doc/README
+++ b/testcases/kdump/doc/README
@@ -82,7 +82,7 @@ directory shows where you are in the test run. When the "Test run
 complete" entry appears in that file, you're done. Verbose log can be
 found at /tmp/kdump.log.
 
-* The test machine would be unavailabe for any other work during the
+* The test machine would be unavailable for any other work during the
 period of the test run.
 
 * System may hang if incorrect partition information is provided for


### PR DESCRIPTION
Fix: #357

Fix typo "unavailable" and "parition" in README for kdump.

Signed-off-by: Fang Guan fguan322@gmail.com