### PR TITLE
Remove redundant blank lines at the end of doc

### DIFF
--- a/testcases/misc/math/float/README
+++ b/testcases/misc/math/float/README
@@ -58,6 +58,3 @@ Notes:
 3) number of loops is initialized to 500 (ability to view cpus loading)
 
 4) these tests have been started on ia64 and ia32 architectures.
-
-
-


### PR DESCRIPTION
Fix: #358 

Remove redundant blank lines at the end of documents.

Signed-off-by: Fang Guan fguan322@gmail.com