### PR TITLE
Remove redundant blank lines at the beginning of document

### DIFF
--- a/testcases/open_posix_testsuite/README
+++ b/testcases/open_posix_testsuite/README
@@ -1,4 +1,3 @@
-
 SECTIONS:
 1. Open POSIX* Test Suite Overview
 2. Design Goals


### PR DESCRIPTION
Fix: #359 

Remove redundant blank lines at the beginning of document.

Signed-off-by: Fang Guan fguan322@gmail.com