### PR TITLE
Fix spelling error in doc

### DIFF
--- a/testcases/open_posix_testsuite/functional/threads/README
+++ b/testcases/open_posix_testsuite/functional/threads/README
@@ -15,4 +15,4 @@ scheduling behavior when threads has realtime priority.
 pi_test - Test Priority Inheritence.
 
 robust_test - This suite is not proper to exist in PTS, since
-the work of adding Robust Mutex to POSIX is still on going.
+the work of adding Robust Mutex to POSIX is still ongoing.


### PR DESCRIPTION
Fix: #361

Fix spelling error in the document.

Signed-off-by: Fang Guan fguan322@gmail.com