### PR TITLE
README: Fix typos

### DIFF
--- a/testcases/kdump/README
+++ b/testcases/kdump/README
@@ -82,9 +82,9 @@ directory shows where you are in the test run. When the "Test run
 complete" entry appears in that file, you're done. Verbose log can be
 found at /tmp/kdump-<date>.log.
 
-* The test machine would be unavailabe for any other work during the
+* The test machine would be unavailable for any other work during the
 period of the test run.
 
 * System may hang if incorrect partition information is provided for
 dumping, like specifying a partition which does not exist, specifying a
-parition label which does not exist. This is not ltp kdump bug.
+partition label which does not exist. This is not ltp kdump bug.

--- a/testcases/kdump/doc/README
+++ b/testcases/kdump/doc/README
@@ -82,9 +82,9 @@ directory shows where you are in the test run. When the "Test run
 complete" entry appears in that file, you're done. Verbose log can be
 found at /tmp/kdump.log.
 
-* The test machine would be unavailabe for any other work during the
+* The test machine would be unavailable for any other work during the
 period of the test run.
 
 * System may hang if incorrect partition information is provided for
 dumping, like specifying a partition which does not exist, specifying a
-parition label which does not exist. This is not ltp kdump bug.
+partition label which does not exist. This is not ltp kdump bug.

--- a/testcases/kernel/controllers/cpuctl/README
+++ b/testcases/kernel/controllers/cpuctl/README
@@ -16,7 +16,7 @@ cpuctl_testN.c
 These are the tasks to run for cpu controller testing.
 The tasks have been automated in the sense that they can assign themselves to
 the appropriate group, can modify their group shares, can migrate etc.
-Each task runs for an interval TIME_INTERVAL seconds and eports the total time
+Each task runs for an interval TIME_INTERVAL seconds and reports the total time
 it could run on all cpus in an interval of INTERVAL seconds. (for convinience
 calculate cpu time is given in % and seconds both).
 A task can call a library routine from libcontrollers library to calculate
@@ -33,7 +33,7 @@ This file contains the functions which do setup for the test. It creates a
 /dev/cpuctl directory, mounts cgroup filesystem on it with cpu. It then creates
 a number(n) of groups in /dev/cpuctl. The cleanup function does a complete cleanup
 of the system.
-(*However most of the error scenarios ahve been tested for a sane cleanup, still if
+(*However most of the error scenarios have been tested for a sane cleanup, still if
 sometime it is unable to do it justt manualy execute the commands written in cleanup
 function)
 

--- a/testcases/kernel/fs/mongo/README
+++ b/testcases/kernel/fs/mongo/README
@@ -12,7 +12,7 @@ Where :
 The benchmark will be performed on given device with
 reiserfs and ext2. Then results will be compared.
 
-The relults directory : ./results
+The results directory : ./results
 The comparision *.html and *.txt files in ./results/html
 
 Warning : All info will be erased on device.

--- a/testcases/kernel/io/direct_io/README
+++ b/testcases/kernel/io/direct_io/README
@@ -15,7 +15,7 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 
-The directory consists of follwing:
+The directory consists of following:
 	diotest_routines.c:	Routines to support the test programs.
 	diotest[1-6].c:		6 test programs with 30 test blocks.
 	Makefile:		To compile the programs.

--- a/testcases/kernel/io/disktest/README
+++ b/testcases/kernel/io/disktest/README
@@ -132,7 +132,7 @@ ON THE TODO LIST
   - Butterfly seek option: test will seek block
     start/end/start+1/end-1/.../end-1/start+1/end/start
   - Ping-Pong seek option: test will seek block start/end/start/end/etc...
-  - min seek: force a minimum seek disktance during any IO access
+  - min seek: force a minimum seek distance during any IO access
   - max seek: force a maximum seek distance during any IO access
   - add metric for the average response time for all IOs
   - implement flock for filesystem testing on clusters

--- a/testcases/open_posix_testsuite/functional/threads/README
+++ b/testcases/open_posix_testsuite/functional/threads/README
@@ -15,4 +15,4 @@ scheduling behavior when threads has realtime priority.
 pi_test - Test Priority Inheritence.
 
 robust_test - This suite is not proper to exist in PTS, since
-the work of adding Robust Mutex to POSIX is still on going.
+the work of adding Robust Mutex to POSIX is still ongoing.

--- a/utils/ffsb-6.0-rc2/README
+++ b/utils/ffsb-6.0-rc2/README
@@ -59,7 +59,7 @@ filesystems), num_threadgroups (number of threadgroups), and time
 directio   - each call to open will be made using O_DIRECT
 alignio    - aligns all block operations for random reads and writes
              on 4k boundaries.
-bufferedio - currently ignorred: it is intended to use libc
+bufferedio - currently ignored: it is intended to use libc
              fread,rwrite, instead of just unix read and write calls
 verbose    - currently ignored
 
@@ -136,7 +136,7 @@ reads  - read() calls with an overall amount and a blocksize
 
 	 If random_read is specified, then the each individual blocks
          will be read starting from a random point with the file, and
-         this will continune until the entire amount specifed has been
+         this will continue until the entire amount specified has been
          read.  This offset of each random block will be totally
          random to the byte level, unless the "alignio" global parameter
          is on, and then the reads will be 4096 byte aligned.  This is
@@ -156,7 +156,7 @@ writes - write() calls with an overall amount and blocksize
 
 	 If random_write is specified, then the each individual blocks
          will be written starting from a random point with the file, and
-         this will continune until the entire amount specifed has been
+         this will continue until the entire amount specified has been
          written out.  This offset of each random block will be totally
          random to the byte level, unless the "alignio" global parameter
          is on, and then the writes will be 4096 byte aligned.  This
@@ -195,7 +195,7 @@ Running the benchmark:
 There are three phases to running the benchmark, aging, fileset
 creates, and the benchmark phase.
 
-The create phase is carried out across all filesystems simultanously
+The create phase is carried out across all filesystems simultaneously
 with one dedicated thread per filesystem.
 
 After the create phase, sync() is called to ensure all dirty data gets


### PR DESCRIPTION
Fix: #366

Fix several typos in README documents.

Signed-off-by: Fang Guan <fguan322@gmail.com>