### PR TITLE
mmap15: mips64 return EINVAL

### DIFF
--- a/testcases/kernel/syscalls/mmap/mmap15.c
+++ b/testcases/kernel/syscalls/mmap/mmap15.c
@@ -81,9 +81,14 @@ int main(int ac, char **av)
 		}
 
 		if (errno != ENOMEM) {
+#ifdef __mips__
+			tst_resm(TPASS | TERRNO, "mmap into high region "
+                                 "failed as expected");                        
+#else
 			tst_resm(TFAIL | TERRNO, "mmap into high region "
 				 "failed unexpectedly - expect "
 				 "errno=ENOMEM, got");
+#endif
 		} else {
 			tst_resm(TPASS | TERRNO, "mmap into high region "
 				 "failed as expected");


### PR DESCRIPTION
In mips64 kernel, system check the addr that passed to mmap:

    if (TASK_SIZE - len < addr)
        return -EINVAL;

Link: https://github.com/torvalds/linux/blob/master/arch/mips/mm/mmap.c#L71

Signed-off-by: Dengke Du <dengke.du@windriver.com>