### PR TITLE
Typo corrections

### DIFF
--- a/testcases/kernel/connectors/pec/pec_listener.c
+++ b/testcases/kernel/connectors/pec/pec_listener.c
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
 		} else {
 			switch (nlhdr->nlmsg_type) {
 			case NLMSG_ERROR:
-				fprintf(stderr, "err message recieved.\n");
+				fprintf(stderr, "err message received.\n");
 				exit(1);
 				break;
 			case NLMSG_DONE:

--- a/testcases/kernel/containers/pidns/pidns20.c
+++ b/testcases/kernel/containers/pidns/pidns20.c
@@ -66,7 +66,7 @@ int broken = 1;			/* broken should be 0 when test completes properly */
 static void child_signal_handler(int sig, siginfo_t * si, void *unused)
 {
 	if (si->si_signo != SIGUSR1)
-		tst_resm(TBROK, "cinit: recieved %s unexpectedly!",
+		tst_resm(TBROK, "cinit: received %s unexpectedly!",
 			 strsignal(si->si_signo));
 	else
 		tst_resm(TPASS, "cinit: user function is called as expected");

--- a/testcases/kernel/controllers/memctl/memctl_test01.c
+++ b/testcases/kernel/controllers/memctl/memctl_test01.c
@@ -87,18 +87,18 @@ int main(void)
 		sprintf(mygroup, "%s", mygroup_p);
 	} else {
 		tst_brkm(TBROK, cleanup,
-			 "invalid parameters recieved from script\n");
+			 "invalid parameters received from script\n");
 	}
 
 	/* XXX (garrcoop): this section really needs error handling. */
 
-	/* Signal handling for SIGUSR1 recieved from script */
+	/* Signal handling for SIGUSR1 received from script */
 	sigemptyset(&newaction1.sa_mask);
 	newaction1.sa_handler = signal_handler_sigusr1;
 	newaction1.sa_flags = 0;
 	sigaction(SIGUSR1, &newaction1, &oldaction1);
 
-	/* Signal handling for SIGUSR2 recieved from script */
+	/* Signal handling for SIGUSR2 received from script */
 	sigemptyset(&newaction2.sa_mask);
 	newaction2.sa_handler = signal_handler_sigusr2;
 	newaction2.sa_flags = 0;

--- a/testcases/kernel/device-drivers/agp/user_space/user_tagp.c
+++ b/testcases/kernel/device-drivers/agp/user_space/user_tagp.c
@@ -266,11 +266,11 @@ int main()
 	else
 		printf("Success on agp_generic_alloc_page\n");
 
-	/* make test calls for agp_generic_destory_page */
+	/* make test calls for agp_generic_destroy_page */
 	if (ki_generic(tagp_fd, TEST_GENERIC_ALLOC_PAGE))
-		printf("Fail on agp_generic_destory_page\n");
+		printf("Fail on agp_generic_destroy_page\n");
 	else
-		printf("Success on agp_generic_destory_page\n");
+		printf("Success on agp_generic_destroy_page\n");
 
 	/* make test calls for agp_enable */
 	if (ki_generic(tagp_fd, TEST_ENABLE))

--- a/testcases/kernel/device-drivers/dev_sim_framework/README
+++ b/testcases/kernel/device-drivers/dev_sim_framework/README
@@ -5,7 +5,7 @@ To run the test case simply enter the user_space directory, type make
 to compile the program, and run ./test_mod in this case, or whatver
 you have named your program. However, the test kernel module must be
 loaded before the test case can work. If the module is not loaded you
-will recieve an error when attempting to open the module.
+will receive an error when attempting to open the module.
 
 Enter the kernel_space directory, and again type make to compile the
 module. After successful compilation use the load script to load the

--- a/testcases/kernel/hotplug/memory_hotplug/commands.c
+++ b/testcases/kernel/hotplug/memory_hotplug/commands.c
@@ -432,7 +432,7 @@ static int get_arg_nodeid_list(char *args, unsigned int *list)
 static int get_current_nodeid_list(unsigned int *fromids)
 {
 	/*
-	 * FIXME (garrcoop): gcp is unitialized and shortly hereafter used in
+	 * FIXME (garrcoop): gcp is uninitialized and shortly hereafter used in
 	 * an initialization statement..... UHHHHHHH... test writer fail?
 	 */
 	glctx_t *gcp;

--- a/testcases/kernel/mem/mtest06/shmat1.c
+++ b/testcases/kernel/mem/mtest06/shmat1.c
@@ -99,13 +99,13 @@ int done_shmat = 0;		/* disallow read and writes before shmat      */
 /* Function:	sig_handler						      */
 /*									      */
 /* Description:	handle SIGALRM raised by set_timer(), SIGALRM is raised when  */
-/*		the timer expires. If any other signal is recived exit the    */
+/*		the timer expires. If any other signal is received exit the   */
 /*		test.							      */
 /*									      */
 /* Input:	signal - signal number, intrested in SIGALRM!		      */
 /*									      */
-/* Return:	exit -1 if unexpected signal is recived			      */
-/*		exit 0 if SIGALRM is recieved			              */
+/* Return:	exit -1 if unexpected signal is received		      */
+/*		exit 0 if SIGALRM is received			              */
 /*									      */
 /******************************************************************************/
 static void sig_handler(int signal,	/* signal number, set to handle SIGALRM       */

--- a/testcases/kernel/sched/sched_stress/sched_tc1.c
+++ b/testcases/kernel/sched/sched_stress/sched_tc1.c
@@ -192,7 +192,7 @@ void process_file(char *filename)
 +---------------------------------------------------------------------*/
 void signal_handler(int signal)
 {
-	printf("signal recieved is %d\n", signal);
+	printf("signal received is %d\n", signal);
 	if (signal == SIGUSR1) {
 		signaled++;
 		if (debug)

--- a/testcases/kernel/syscalls/kill/kill06.c
+++ b/testcases/kernel/syscalls/kill/kill06.c
@@ -120,7 +120,7 @@ int main(int ac, char **av)
 			TEST(kill(-getpgrp(), TEST_SIG));
 			sleep(300);
 
-			tst_resm(TINFO, "%d never recieved a"
+			tst_resm(TINFO, "%d never received a"
 				 " signal", getpid());
 			exit(exno);
 		} else {
@@ -162,7 +162,7 @@ void do_child(void)
 
 	sleep(299);
 
-	tst_resm(TINFO, "%d never recieved a" " signal", getpid());
+	tst_resm(TINFO, "%d never received a" " signal", getpid());
 	exit(exno);
 }
 

--- a/testcases/kernel/syscalls/kill/kill07.c
+++ b/testcases/kernel/syscalls/kill/kill07.c
@@ -199,7 +199,7 @@ void do_child(void)
 	int exno = 1;
 
 	sleep(300);
-	tst_resm(TINFO, "Child never recieved a signal");
+	tst_resm(TINFO, "Child never received a signal");
 	exit(exno);
 }
 

--- a/testcases/kernel/syscalls/kill/kill10.c
+++ b/testcases/kernel/syscalls/kill/kill10.c
@@ -329,7 +329,7 @@ void setup(void)
 			    ("%d: Master pausing for Managers to check in (%d/%d)\n",
 			     mypid, pgrps_ready, num_pgrps);
 		/*
-		 * We might recieve the signal from the (last manager) before
+		 * We might receive the signal from the (last manager) before
 		 * we issue a pause. In that case we might hang even if we have
 		 * all the managers reported in. So set an alarm so that we can
 		 * wake up.
@@ -704,7 +704,7 @@ void fork_procs(int procs_left)
 				if (debug_flag >= 8)
 					printf("%d: child pausing\n", mypid);
 				/*
-				 * If we have already recieved the signal, we dont
+				 * If we have already received the signal, we dont
 				 * want to pause for it !
 				 */
 				while (!signal_parents_flag) {

--- a/testcases/kernel/syscalls/move_pages/move_pages_support.c
+++ b/testcases/kernel/syscalls/move_pages/move_pages_support.c
@@ -322,7 +322,7 @@ void free_shared_pages(void **pages, unsigned int num)
  * @num - no. of semaphores to create
  *
  * Allocate and initialize semaphores in a shared memory area, so that
- * the semaphore can be used accross processes.
+ * the semaphore can be used across processes.
  *
  * RETURNS:
  * Array of initialized semaphores.

--- a/testcases/kernel/syscalls/pause/pause02.c
+++ b/testcases/kernel/syscalls/pause/pause02.c
@@ -96,7 +96,7 @@ int main(int ac, char **av)
 		if (WIFSIGNALED(status)) {
 			switch (WTERMSIG(status)) {
 			case SIGALRM:
-				tst_resm(TFAIL, "Timeout: SIGINT wasn't recieved by child");
+				tst_resm(TFAIL, "Timeout: SIGINT wasn't received by child");
 			break;
 			default:
 				tst_resm(TFAIL, "Child killed by signal");

--- a/testcases/kernel/syscalls/prctl/prctl03.c
+++ b/testcases/kernel/syscalls/prctl/prctl03.c
@@ -14,7 +14,7 @@
  *    created by fork(2).
  * 3) PR_GET_CHILD_SUBREAPER can get the setting of PR_SET_CHILD_SUBREAPER.
  *
- * These flags was added by kenrel commit ebec18a6d3aa:
+ * These flags was added by kernel commit ebec18a6d3aa:
  * "prctl: add PR_{SET,GET}_CHILD_SUBREAPER to allow simple process supervision"
  */
 

--- a/testcases/kernel/syscalls/waitpid/waitpid02.c
+++ b/testcases/kernel/syscalls/waitpid/waitpid02.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
 						 "unexpected pid returned");
 				} else {
 					tst_resm(TPASS,
-						 "recieved expected pid");
+						 "received expected pid");
 				}
 
 				nsig = WTERMSIG(status);
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 					tst_resm(TFAIL, "waitpid error: "
 						 "unexpected signal returned");
 				} else {
-					tst_resm(TPASS, "recieved expected "
+					tst_resm(TPASS, "received expected "
 						 "signal");
 				}
 
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
 						 "unexpected exit number "
 						 "returned");
 				} else {
-					tst_resm(TPASS, "recieved expected "
+					tst_resm(TPASS, "received expected "
 						 "exit value");
 				}
 			}

--- a/testcases/open_posix_testsuite/Documentation/COVERAGE.threads
+++ b/testcases/open_posix_testsuite/Documentation/COVERAGE.threads
@@ -77,7 +77,7 @@ pthread_key_create		YES		MED
 pthread_key_delete		YES		MED
 pthread_mutexattr_getpshared	YES		LOW
 pthread_mutexattr_setpshared	YES		LOW
-pthread_rwlock_destory		YES		LOW
+pthread_rwlock_destroy		YES		LOW
 pthread_rwlock_init		YES		LOW
 pthread_rwlock_rdlock		YES		LOW
 pthread_rwlock_timedrdlock	YES		LOW
@@ -86,7 +86,7 @@ pthread_rwlock_tryrdlock	YES		LOW
 pthread_rwlock_trywrlock	YES		LOW
 pthread_rwlock_unlock		YES		LOW
 pthread_rwlock_wrlock		YES		LOW
-pthread_rwlockattr_destory	YES		LOW
+pthread_rwlockattr_destroy	YES		LOW
 pthread_rwlockattr_getpshared	YES		LOW
 pthread_setspecific		YES		MED
 */

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_attr_destroy/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_attr_destroy/1-1.c
@@ -6,7 +6,7 @@
  * source tree.
 
  *  Test that pthread_attr_destroy()
- *  shall destory a thread attributes object.  An implementation may cause
+ *  shall destroy a thread attributes object.  An implementation may cause
  *  pthread_attr_destroy() to set 'attr' to an implementation-defined invalid
  *  value.
  *

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_attr_destroy/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_attr_destroy/assertions.xml
@@ -4,7 +4,7 @@
 
    int pthread_attr_destroy(pthread_attr_t *attr)
 
-  destorys a thread attributes object.  An implementation may cause
+  destroys a thread attributes object.  An implementation may cause
   pthread_attr_destroy() to set 'attr' to an implementation-defined invalid
   value.
   </assertion>

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_barrier_init/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_barrier_init/3-1.c
@@ -35,7 +35,7 @@ int main(void)
 
 	if (rc != EINVAL) {
 		printf
-		    ("Test FAILED: pthread_barrier_init() does not return EINVAL when intializing a barrier with count=0,"
+		    ("Test FAILED: pthread_barrier_init() does not return EINVAL when initializing a barrier with count=0,"
 		     " return code %d, %s\n", rc, strerror(rc));
 		return PTS_FAIL;
 	}

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_create/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_create/2-1.c
@@ -40,7 +40,7 @@ int main(void)
 	 * it is joinable. */
 	ret = pthread_create(&new_th, NULL, a_thread_func, NULL);
 	if (ret) {
-		fprintf(stderr, "ptread_create(): %s\n", strerror(ret));
+		fprintf(stderr, "pthread_create(): %s\n", strerror(ret));
 		return PTS_UNRESOLVED;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/1-1.c
@@ -103,7 +103,7 @@ int main(void)
 		printf("Test FAILED: Kill request timed out\n");
 		return PTS_FAIL;
 	} else if (handler_called == 0) {
-		printf("Test FAILED: Thread did not recieve or handle\n");
+		printf("Test FAILED: Thread did not received or handle\n");
 		return PTS_FAIL;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_destroy/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_destroy/assertions.xml
@@ -19,7 +19,7 @@
   <assertion id="4" tag="ref:XSH6:33657:33661">
   pthread_mutex_destroy() may fail if:
 
-  -[EBUSY] The implementation has detected an attempt to destory the
+  -[EBUSY] The implementation has detected an attempt to destroy the
   object referenced by 'mutex' while it is locked or referenced.
   -[EINVAL] The value specified by 'mutex' is invalid.
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_init/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_init/2-1.c
@@ -45,7 +45,7 @@ int main(void)
 
 	/* Destory the mutex object */
 	if ((rc = pthread_mutex_destroy(&mutex)) != 0) {
-		fprintf(stderr, "Fail to destory the mutex, rc=%d\n", rc);
+		fprintf(stderr, "Fail to destroy the mutex, rc=%d\n", rc);
 		return PTS_UNRESOLVED;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_init/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_init/assertions.xml
@@ -14,14 +14,14 @@
   </assertion>
   <assertion id="2" tag="ref:XSH6:33640:33645">
   Upon successful initialization, the state of the mutex becomes initialized
-  and unlocked.  Attempting to initialize an already intialized mutex
+  and unlocked.  Attempting to initialize an already initialized mutex
   results in undefined behavior.
   </assertion>
   <assertion id="3" tag="ref:XSH6:33646:33649">
   In cases where default mutex attributes are appropriate, the macro
   PTHREAD_MUTEX_INITIALIZER can be used to intiailize mutexes that are
   statically allocated.  The effect shall be equivilant to dynamic
-  intialization by a call to pthread_mutex_init() with paramter 'attr'
+  initialization by a call to pthread_mutex_init() with paramter 'attr'
   specified as NULL, except that no error checks are performed.
   </assertion>
   <assertion id="4" tag="ref:XSH6:33651:33651">
@@ -31,14 +31,14 @@
   It SHALL fail if:
 
   -[EAGAIN] The system lacked the neccessary resources (other than memory)
-  to intialize another mutex.
+  to initialize another mutex.
   -[ENOMEM] Insufficient memory exists to initialize the mutex.
  -[EPERM] The caller does not have the privilage to perform the operation.
 
   It MAY fail if:
 
   -[EBUSY] The implementation has detected an attempt to reinitialize the
-   object referenced by 'mutex', a previously intialized, but not yet
+   object referenced by 'mutex', a previously initialized, but not yet
    destroyed, mutex.
   -[EINVAL] The value specified by 'attr' is invalid.
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_getprioceiling/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_getprioceiling/3-1.c
@@ -32,7 +32,7 @@ int main(void)
 	int prioceiling, ret;
 	pthread_mutexattr_t mta;
 
-	/* Get the prioceiling of an unintialized mutex attr. */
+	/* Get the prioceiling of an uninitialized mutex attr. */
 	if ((ret = pthread_mutexattr_getprioceiling(&mta, &prioceiling)) == 0) {
 		printf
 		    ("Test PASSED: *Note: Returned 0 instead of EINVAL when passed an uninitialized mutex attribute object to pthread_mutexattr_getprioceiling, but standard says 'may' fail.\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_setprioceiling/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_setprioceiling/3-1.c
@@ -38,7 +38,7 @@ int main(void)
 
 	prioceiling = sched_get_priority_min(SCHED_FIFO);
 
-	/* Set the prioceiling of an unintialized mutex attr. */
+	/* Set the prioceiling of an uninitialized mutex attr. */
 	if ((ret = pthread_mutexattr_setprioceiling(&mta, prioceiling)) == 0) {
 		printf
 		    ("Test PASSED: *Note: Returned 0 instead of EINVAL when passed an uninitialized mutex attribute object to pthread_mutexattr_setprioceiling, but standard says 'may' fail.\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/2-1.c
@@ -59,7 +59,7 @@ int main(void)
 
 	/* Initialize the mutex with that attribute obj. */
 	if (pthread_mutex_init(&mutex, &mta) != 0) {
-		perror("Error intializing the mutex.\n");
+		perror("Error initializing the mutex.\n");
 		return PTS_UNRESOLVED;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-1.c
@@ -48,7 +48,7 @@ int main(void)
 
 	/* Initialize the mutex with that attribute obj. */
 	if (pthread_mutex_init(&mutex, &mta) != 0) {
-		perror("Error intializing the mutex.\n");
+		perror("Error initializing the mutex.\n");
 		return PTS_UNRESOLVED;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-2.c
@@ -61,7 +61,7 @@ int main(void)
 
 	/* Initialize the mutex with that attribute obj. */
 	if (pthread_mutex_init(&mutex, &mta) != 0) {
-		perror("Error intializing the mutex.\n");
+		perror("Error initializing the mutex.\n");
 		return PTS_UNRESOLVED;
 	}
 
@@ -91,7 +91,7 @@ int main(void)
 	pthread_mutex_destroy(&mutex);
 
 	if (pthread_mutexattr_destroy(&mta)) {
-		perror("Error at pthread_mutexattr_destory().\n");
+		perror("Error at pthread_mutexattr_destroy().\n");
 		return PTS_UNRESOLVED;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-3.c
@@ -48,7 +48,7 @@ int main(void)
 
 	/* Initialize the mutex with that attribute obj. */
 	if (pthread_mutex_init(&mutex, &mta) != 0) {
-		perror("Error intializing the mutex.\n");
+		perror("Error initializing the mutex.\n");
 		return PTS_UNRESOLVED;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutexattr_settype/3-4.c
@@ -48,7 +48,7 @@ int main(void)
 
 	/* Initialize the mutex with that attribute obj. */
 	if (pthread_mutex_init(&mutex, &mta) != 0) {
-		perror("Error intializing the mutex.\n");
+		perror("Error initializing the mutex.\n");
 		return PTS_UNRESOLVED;
 	}
 
@@ -70,12 +70,12 @@ int main(void)
 	}
 
 	if (pthread_mutex_destroy(&mutex)) {
-		perror("Error at pthread_mutex_destory().\n");
+		perror("Error at pthread_mutex_destroy().\n");
 		return PTS_UNRESOLVED;
 	}
 
 	if (pthread_mutexattr_destroy(&mta)) {
-		perror("Error at pthread_mutexattr_destory().\n");
+		perror("Error at pthread_mutexattr_destroy().\n");
 		return PTS_UNRESOLVED;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_init/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_init/6-1.c
@@ -39,7 +39,7 @@ int main(void)
 		return PTS_FAIL;
 	}
 
-	/* Re-intialize without destroying it first */
+	/* Re-initialize without destroying it first */
 	rc = pthread_rwlock_init(&rwlock, NULL);
 
 	/* Cleanup */

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_init/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_init/assertions.xml
@@ -24,7 +24,7 @@
   </assertion>
 
   <assertion id="5" tag="ref:XSH6:34718:34722">
-  ptread_rwlock_init( ) function shall fail if:
+  pthread_rwlock_init( ) function shall fail if:
   [EAGAIN] The system lacked the necessary resources (other than memory) to initialize
   another read-write lock.
   [ENOMEM] Insufficient memory exists to initialize the read-write lock.

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/assertions.xml
@@ -18,7 +18,7 @@
 	the lock or a writer with the appropriate priority was blocked on it.
 
 	It may fail if:
-	[EINVAL] rwlock does not refer to an intialized read-write lock object
+	[EINVAL] rwlock does not refer to an initialized read-write lock object
 
 	It shall not return EINTR.
    </assertion>

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c
@@ -7,7 +7,7 @@
  * Test pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock)
  *
  *	It may fail if:
- *	[EINVAL] rwlock does not refer to an intialized read-write lock object
+ *	[EINVAL] rwlock does not refer to an initialized read-write lock object
  *
  * Steps:
  * 1. Call pthread_rwlock_trywrlock with an uninitialized rwlock object

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
@@ -7,7 +7,7 @@
  * Test that pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
  *
  *	It 'may' fail if:
- *	[EINVAL]  rwlock doesn't refer to an intialized read-write lock
+ *	[EINVAL]  rwlock doesn't refer to an initialized read-write lock
  *	[EPERM]  the current thread doesn't hold the lock on the rwlock
  *
  *	Testing EINVAL in this test.

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-2.c
@@ -7,7 +7,7 @@
  * Test that pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
  *
  *	It 'may' fail if:
- *	[EINVAL]  rwlock doesn't refer to an intialized read-write lock
+ *	[EINVAL]  rwlock doesn't refer to an initialized read-write lock
  *	[EPERM]  the current thread doesn't hold the lock on the rwlock
  *
  *	Testing EPERM in this test.

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/assertions.xml
@@ -28,7 +28,7 @@
 	If successful, the pthread_rwlock_unlock( ) function shall return zero;
 	otherwise, an error number shall be returned to indicate the error.
 
-	[EINVAL]  rwlock doesn't refer to an intialized read-write lock
+	[EINVAL]  rwlock doesn't refer to an initialized read-write lock
 	[EPERM]  the current thread doesn't hold the lock on the rwlock
 
 	The pthread_rwlock_unlock( ) function shall not return an error code of [EINTR].

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlockattr_init/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlockattr_init/2-1.c
@@ -51,7 +51,7 @@ int main(void)
 	}
 
 	if ((rc = pthread_rwlockattr_destroy(&rwa)) != 0) {
-		printf("Error at pthread_rwlockattr_destory()\n");
+		printf("Error at pthread_rwlockattr_destroy()\n");
 		return PTS_UNRESOLVED;
 	}
 	if ((rc = pthread_rwlock_unlock(&rwl1)) != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_destroy/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_destroy/3-1.c
@@ -7,7 +7,7 @@
  */
 
 /*
- * Test case vrifies sem_destroy shall destroy on intialized semaphore
+ * Test case verifies sem_destroy shall destroy on initialized semaphore
  * upon which no threads are currently blocked.
  */
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigsuspend/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigsuspend/1-1.c
@@ -32,7 +32,7 @@
     process allowed for enough time for the child process to complete execution
     and get to the "return 2" line at the very end of the child's code, but the
     parent didn't allow for any time in which the child may have been suspended.
-    Because the child did recieve the signal that the parent later sent before
+    Because the child did receive the signal that the parent later sent before
     the child finished executing, that had to have meant that the child was
     suspended for a while during it's execution.
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigsuspend/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigsuspend/4-1.c
@@ -20,7 +20,7 @@
     the child return to the parent process with:
     - a return value of 1 if the original signal mask was not restored, or
     - a return value of 0 if the original signal mask was successfully restored.
- 4. Finally from the parent, return a PTS_PASS if recieved the return value of the child was not
+ 4. Finally from the parent, return a PTS_PASS if received the return value of the child was not
     a 1.
 
 */

--- a/testcases/realtime/00_Descriptions.txt
+++ b/testcases/realtime/00_Descriptions.txt
@@ -168,7 +168,7 @@ func/pthread_kill_latency testcases :
 ====================================
 pthread_kill_latency.c:
 - Measures the latency involved in sending a signal to a thread using
-  pthread_kill.  Two threads are created - the one that recieves the signal
+  pthread_kill.  Two threads are created - the one that receives the signal
   (thread1) and other that sends signal (thread2).  Before sending the signal,
   the thread2 waits for thread1 to initialize, notes the time and sends
   pthread_kill signal to thread1.  Thread2, which has defined a handler for the

--- a/testcases/realtime/func/pthread_kill_latency/pthread_kill_latency.c
+++ b/testcases/realtime/func/pthread_kill_latency/pthread_kill_latency.c
@@ -25,7 +25,7 @@
  *      signal (thread1) and the other that sends the signal (thread2). Before
  *      sending the signal, the thread2 waits for thread1 to initialize, notes
  *      the time and sends pthread_kill signal to thread1. thread2, which has
- *      defined a handler for the signal, notes the time it recieves the signal.
+ *      defined a handler for the signal, notes the time it receives the signal.
  *      The maximum and the minimum latency is reported.
  *
  *

--- a/testcases/realtime/profiles/default
+++ b/testcases/realtime/profiles/default
@@ -29,7 +29,7 @@ func/pi_perf			pi_perf -c 200
 # Default=20 us
 func/pthread_kill_latency	pthread_kill_latency -c 20
 
-# Pass if all treads get preempted within max loops.
+# Pass if all threads get preempted within max loops.
 # Default max=1
 func/prio-preempt		prio-preempt -c 1
 

--- a/utils/ffsb-6.0-rc2/rbt.h
+++ b/utils/ffsb-6.0-rc2/rbt.h
@@ -41,7 +41,7 @@
  * - The contained TYPE class represents the objects stored in the tree.
  *   It has to support the copy constructor and the assignment operator (opr)
  * - cmp is a functor used to define the order of objects of class TYPE:
- *   This class has to support an operator() that recieves two objects from
+ *   This class has to support an operator() that receives two objects from
  *   the TYPE class and returns a negative, 0, or a positive integer,
  *   depending on the comparison result.
  *


### PR DESCRIPTION
* accross -> across
* destory -> destroy
* intialization -> initialization
* intialize -> initialize
* intialized -> initialized
* intializing -> initializing
* kenrel -> kernel
* ptread -> pthread
* recieved -> received
* tread -> thread
* unitialized -> uninitialized
* unintialized -> uninitialized
* vrifies -> verifies

All changes are all in comments and strings, no function name changes.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>