### PR TITLE
syscalls/ptrace05: skip internally used signals

### DIFF
--- a/testcases/kernel/syscalls/ptrace/ptrace05.c
+++ b/testcases/kernel/syscalls/ptrace/ptrace05.c
@@ -71,6 +71,9 @@ int main(int argc, char **argv)
 
 	for (signum = start_signum; signum <= end_signum; signum++) {
 
+		if (signum >= __SIGRTMIN && signum < SIGRTMIN)
+			continue;
+
 		switch (child = fork()) {
 		case -1:
 			tst_brkm(TBROK | TERRNO, NULL, "fork() failed");


### PR DESCRIPTION
Some signals may be internally used by the C library. Do not attempt to
test these.

Signed-off-by: Steve Muckle <smuckle@google.com>