### PR TITLE
[open_posix_testsuite] Add tests for open() api

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/open/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/1-1.c
@@ -1,0 +1,93 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * Establish the connection between file and file descriptor
+ *
+ * method:
+ *	-open file in write mode using open()
+ *	-write 1 sample string into a file
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file
+ *	-compare the value read with the value written in first step
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/1-1.c"
+#define STR_CONST "POSIX CONFORMANCE TEST"
+
+static void remove_file(char *file_name)
+{
+	errno = 0;
+	(void)unlink(file_name);
+}
+
+int main(void)
+{
+	int test_fd, read_bytes, write_bytes;
+	char read_value[sizeof(STR_CONST)] = {};
+	char file_str[BUF_SIZE];
+	char *filename_p;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	test_fd = open(filename_p, O_CREAT | O_WRONLY, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	write_bytes = write(test_fd, STR_CONST, sizeof(STR_CONST));
+	if (write_bytes < 0) {
+		printf(TNAME " Error in write()\n");
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	test_fd = open(filename_p, O_RDONLY);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno = %d, %s\n", errno, strerror(errno));
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	read_bytes = read(test_fd, read_value, write_bytes);
+	if (read_bytes != write_bytes) {
+		printf(TNAME " Wrong data read from file, errno = %d, %s\n", errno, strerror(errno));
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+	if (memcmp(read_value, STR_CONST, read_bytes) == 0) {
+		printf(TNAME " Test Passed, string comparison is successful.\n");
+		remove_file(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed, issue in string comparison.\n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/10-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/10-1.c
@@ -1,0 +1,128 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * If a file is opened using open() and O_APPEND flag is set
+ * the file offset shall be set to the end of file prior to each write.
+ *
+ * method:
+ *	-open file and write STR_CONST_1
+ *	-open file with O_APPEND flag set and write STR_CONST_2
+ *	-using lseek set the offset to beginning of the file and write STR_CONST_3
+ *	-Check the contents of the file
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/10-1.c"
+#define STR_CONST_1 "POSIX "
+#define STR_CONST_2 "CONFORMANCE "
+#define STR_CONST_3 "TEST"
+#define STR_APPEND "POSIX CONFORMANCE TEST"
+
+static void remove_file(char *file_name)
+{
+	errno = 0;
+	(void)unlink(file_name);
+}
+
+int main(void)
+{
+	int test_fd, ret;
+	char result_str[sizeof(STR_APPEND)];
+	char file_str[BUF_SIZE];
+	char *filename_p;
+	errno = 0;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_WRONLY, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	/* size-1 is required as it considers null byte also */
+	ret = write(test_fd, STR_CONST_1, sizeof(STR_CONST_1) - 1);
+	if (ret != sizeof(STR_CONST_1) - 1) {
+		printf(TNAME " Error in write()\n");
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	test_fd = open(filename_p, O_WRONLY | O_APPEND);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno = %d, %s\n", errno, strerror(errno));
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	ret = write(test_fd, STR_CONST_2, sizeof(STR_CONST_2) - 1);
+	if (ret != sizeof(STR_CONST_2) - 1) {
+		printf(TNAME " Error in write()\n");
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (lseek(test_fd, 0, SEEK_SET) < 0) {
+		printf(TNAME " Error in updating the offset to start of file, errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	ret = write(test_fd, STR_CONST_3, sizeof(STR_CONST_3));
+	if (ret != sizeof(STR_CONST_3)) {
+		printf(TNAME " Error in write()\n");
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	test_fd = open(filename_p, O_RDONLY);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno = %d, %s\n", errno, strerror(errno));
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	ret = read(test_fd, result_str, sizeof(STR_APPEND));
+	if (ret != sizeof(STR_APPEND)) {
+		printf(TNAME " Error in read()\n");
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	if (memcmp(result_str, STR_APPEND, sizeof(STR_APPEND)) == 0) {
+		printf(TNAME " Success, file offset is set to end of file for each write with O_APPEND \n");
+		remove_file(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, file offset is not set to end of file with O_APPEND \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/11-1.c
@@ -1,0 +1,71 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When  O_CREAT flag is set and O_DIRECTORY flag is not set, file shall
+ * be created as regular file.
+ *
+ * method:
+ *	-open file using open()
+ *	-check file type using stat
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/11-1.c"
+
+int main(void)
+{
+	int test_fd;
+	struct stat sb;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+	errno = 0;
+	filename_p = tmpnam(file_str);
+
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	stat(filename_p, &sb);
+	if (errno != 0) {
+		printf(TNAME " Error in getting file stat, errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+
+	if (S_ISREG(sb.st_mode)) {
+		printf(TNAME " Success, file is created as regular file\n");
+		unlink(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME, " Error, file is not created as regular file\n");
+		unlink(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/12-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/12-1.c
@@ -1,0 +1,71 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When  O_CREAT flag is set and file does not exist, user-id of file which
+ * is created shall be set to effective userid of the process.
+ *
+ * method:
+ *	-open file using open()
+ *	-check userid file using stat
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/12-1.c"
+
+int main(void)
+{
+	int test_fd;
+	struct stat sb;
+	char file_str[BUF_SIZE];
+	errno = 0;
+	char *filename_p;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	stat(filename_p, &sb);
+	if (errno != 0) {
+		printf(TNAME " Error in getting file stat, errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+
+	if (sb.st_uid == geteuid()) {
+		printf(TNAME " Success, user-id of file is same as effective user-id of process\n");
+		unlink(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME, " Error, user-id of file is not same as effective user-id of process\n");
+		unlink(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/13-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/13-1.c
@@ -1,0 +1,71 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When  O_CREAT flag is set and file does not exist, group-id of file which
+ * is created shall be set to effective groupid of the process.
+ *
+ * method:
+ *	-open file using open()
+ *	-check groupid file using stat
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/13-1.c"
+
+int main(void)
+{
+	int test_fd;
+	struct stat sb;
+	char file_str[BUF_SIZE];
+	errno = 0;
+	char *filename_p;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	stat(filename_p, &sb);
+	if (errno != 0) {
+		printf(TNAME " Error in getting file stat, errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+
+	if (sb.st_gid == getegid()) {
+		printf(TNAME " Success, group-id of file is same as effective group-id of process\n");
+		unlink(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME, "Error, group-id of file is not same as effective group-id of process\n");
+		unlink(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/14-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/14-1.c
@@ -1,0 +1,73 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When  O_CREAT flag is set and file does not exist, permission bits for the file which
+ * is created shall be set as (mode_t & ~umask).
+ *
+ * method:
+ *	-open file using open()
+ *	-check file permissions using stat
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/14-1.c"
+
+int main(void)
+{
+	int test_fd;
+	struct stat sb;
+	char file_str[BUF_SIZE];
+	errno = 0;
+	char *filename_p;
+	mode_t old_mask;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	stat(filename_p, &sb);
+	if (errno != 0) {
+		printf(TNAME " Error in getting file stat, errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	old_mask = umask(0);
+	if ((sb.st_mode & ~S_IFMT) == ((S_IRWXG | S_IRWXU) & ~old_mask)) {
+		printf(TNAME " Success, permission bits of file is as expected\n");
+		umask(old_mask);
+		unlink(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, permission bits of file are not as expected\n");
+		umask(old_mask);
+		unlink(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/15-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/15-1.c
@@ -1,0 +1,70 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When  O_CREAT flag and O_DIRECTORY flag are set and directory is not exist
+ * new directory shall be created.
+ *
+ * method:
+ *	-open directory using O_CREAT and O_DIRECTORY flags
+ *	-check whether directory is created
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/15-1.c"
+
+int main(void)
+{
+	int test_fd, ret;
+	struct stat sb;
+	char dir_str[BUF_SIZE];
+	char *dirname_p;
+	errno = 0;
+
+	dirname_p = tmpnam(dir_str);
+	if (dirname_p == NULL) {
+		printf(TNAME " Error in generating tmp dir name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(dirname_p, O_CREAT | O_DIRECTORY, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		remove(dirname_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	ret = stat(dirname_p, &sb);
+	if (ret != 0 || errno != 0) {
+		printf(TNAME " Error in getting stat, errno = %d, %s\n", errno, strerror(errno));
+		remove(dirname_p);
+		exit(PTS_FAIL);
+	}
+	printf("%d \n", S_ISDIR(sb.st_mode));
+	if (S_ISDIR(sb.st_mode)) {
+		printf(TNAME " Success, Directory is created \n");
+		remove(dirname_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, Directory is not created \n");
+		remove(dirname_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/16-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/16-1.c
@@ -1,0 +1,63 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When  O_DIRECTORY flag is on non directory file, errno will be set
+ * to ENOTDIR.
+ *
+ * method:
+ *	-open file using open()
+ *	-check file permissions using stat
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/16-1.c"
+
+int main(void)
+{
+	int test_fd;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+	errno = 0;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	test_fd = open(filename_p, O_DIRECTORY);
+	if (errno != ENOTDIR) {
+		printf(TNAME " Error, errno is not as expected, errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_FAIL);
+	} else {
+		printf(TNAME " Success, errno is as expected.\n");
+		unlink(filename_p);
+		exit(PTS_PASS);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/18-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/18-1.c
@@ -1,0 +1,64 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When  O_CREAT flag and O_EXCL flags are set and file already exist, errno will be set
+ * to EEXIST
+ *
+ * method:
+ *	-open file using open()
+ *	-reopen same file with O_CREAT and O_EXCL flags
+ *	-check errno
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/18-1.c"
+
+int main(void)
+{
+	int test_fd;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+	errno = 0;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	test_fd = open(filename_p, O_CREAT | O_RDWR | O_EXCL);
+	if (errno != EEXIST) {
+		printf(TNAME " Error, errno is not as expected, errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_FAIL);
+	} else {
+		printf(TNAME " Success, errno is as expected.\n");
+		unlink(filename_p);
+		exit(PTS_PASS);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/3-1.c
@@ -1,0 +1,80 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * FD_CLOEXEC flag associated with new file descriptor will be cleared,
+ * unless O_CLOEXEC oflag is set.
+ *
+ * method:
+ *	-open file in without O_CLOEXEC flag
+ *	-use fcntl to get file descriptor flags
+ *	-Check if FD_CLOEXEC is not set
+ *	-open the same file with O_CLOEXEC flag
+ *	-get file descriptor flags and check if FD_CLOEXEC is set
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/3-1.c"
+
+static void remove_file(char *file_name)
+{
+	errno = 0;
+	(void)unlink(file_name);
+}
+
+int main(void)
+{
+	int test_fd, flags;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+	errno = 0;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	flags = fcntl(test_fd, F_GETFD);
+	if (!(flags & FD_CLOEXEC)) {
+		remove_file(filename_p);
+		printf(TNAME " FD_CLOEXEC flag is cleared by default\n");
+	} else {
+		printf(TNAME " Error, FD_CLOEXEC flag is not cleared \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+	errno = 0;
+	test_fd = open(filename_p, O_CREAT | O_RDWR | O_CLOEXEC);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno = %d, %s\n", errno, strerror(errno));
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	flags = fcntl(test_fd, F_GETFD);
+	if (flags & FD_CLOEXEC) {
+		remove_file(filename_p);
+		printf(TNAME " FD_CLOEXEC flag is set when O_CLOEXEC oflag is used.\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, FD_CLOEXEC flag is not set \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/4-1.c
@@ -1,0 +1,83 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * If a file is opened using open(), the file offset used to mark the current position
+ * within the file shall be set to beginning of the file.
+ *
+ * method:
+ *	-open file using open()
+ *	-using file descriptor check current position
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "posixtest.h"
+
+#define BUF_SIZE 1024
+#define TNAME "open/4-1.c"
+#define STR_CONST "POSIX CONFORMANCE TEST"
+
+static void remove_file(char *file_name)
+{
+	errno = 0;
+	(void)unlink(file_name);
+}
+
+int main(void)
+{
+	int test_fd, ret;
+	errno = 0;
+	off_t offset;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	ret = write(test_fd, STR_CONST, sizeof(STR_CONST));
+	if (ret < 0) {
+		printf(TNAME " Error in write()\n");
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	if (close(test_fd) < 0) {
+		printf(TNAME " Error at close(), errno = %d, %s\n", errno, strerror(errno));
+		unlink(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	test_fd = open(filename_p, O_RDONLY);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno = %d, %s\n", errno, strerror(errno));
+		remove_file(filename_p);
+		exit(PTS_UNRESOLVED);
+	}
+	offset = lseek(test_fd, 0, SEEK_CUR);
+	if (offset == 0) {
+		printf(TNAME " Test Passed, offset is set to beginning of file\n");
+		remove_file(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, offset is not set to beginning of file\n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/6-1.c
@@ -1,0 +1,74 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When O_RDONLY flag is used, file is opened for read only.
+ *
+ * method:
+ *	-open file with O_EXEC flag
+ *	-check read and write operations on file using file descriptor
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "posixtest.h"
+#include <sys/stat.h>
+
+#define BUF_SIZE 1024
+#define TNAME "open/6-1.c"
+
+static void remove_file(char *file_name)
+{
+	errno = 0;
+	(void)unlink(file_name);
+}
+
+int main(void)
+{
+	int test_fd;
+	int *r_ptr, r_val = 0;
+	r_ptr = &r_val;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	test_fd = open(filename_p, O_CREAT | O_RDONLY, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	read(test_fd, r_ptr, sizeof(r_val));
+	if (errno == 0)
+		printf(TNAME " Read operation is allowed on file\n");
+	else {
+		printf(TNAME " Error, read operation is not allowed on file. errno: %d, %s\n", errno, strerror(errno));
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+	errno = 0;
+	write(test_fd, r_ptr, sizeof(r_val));
+	if (errno == EBADF) {
+		printf(TNAME " Success, write operation is not allowed on file.\n");
+		remove_file(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, write operation is allowed on file \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/7-1.c
@@ -1,0 +1,73 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When O_RDWR flag is used, file is opened for read and write.
+ *
+ * method:
+ *	-open file with O_RDWR flag
+ *	-check read and write operations on file using file descriptor
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "posixtest.h"
+#include <sys/stat.h>
+
+#define BUF_SIZE 1024
+#define TNAME "open/7-1.c"
+
+static void remove_file(char *file_name)
+{
+	errno = 0;
+	(void)unlink(file_name);
+}
+
+int main(void)
+{
+	int test_fd;
+	int *r_ptr, r_val = 0;
+	r_ptr = &r_val;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+	errno = 0;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+	test_fd = open(filename_p, O_CREAT | O_RDWR, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	write(test_fd, r_ptr, sizeof(r_val));
+	if (errno == 0)
+		printf(TNAME " Success, write operation allowed on file\n");
+	else {
+		printf(TNAME " Error, write operation is not allowed on file \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+	errno = 0;
+	read(test_fd, r_ptr, sizeof(r_val));
+	if (errno == 0) {
+		printf(TNAME " Success, Read operation is allowed on file\n");
+		remove_file(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, read operation is not allowed on file \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/9-1.c
@@ -1,0 +1,74 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ * When O_WRONLY flag is used, file is opened for write only.
+ *
+ * method:
+ *	-open file with O_WRONLY flag
+ *	-check read and write operations on file using file descriptor
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "posixtest.h"
+#include <sys/stat.h>
+
+#define BUF_SIZE 1024
+#define TNAME "open/9-1.c"
+
+static void remove_file(char *file_name)
+{
+	errno = 0;
+	(void)unlink(file_name);
+}
+
+int main(void)
+{
+	int test_fd, ret;
+	int *r_ptr, r_val = 0;
+	r_ptr = &r_val;
+	char file_str[BUF_SIZE];
+	char *filename_p;
+	errno = 0;
+
+	filename_p = tmpnam(file_str);
+	if (filename_p == NULL) {
+		printf(TNAME " Error in generating tmp file name\n");
+		exit(PTS_UNRESOLVED);
+	}
+
+	test_fd = open(filename_p, O_CREAT | O_WRONLY, S_IRWXG | S_IRWXU);
+	if (test_fd < 0) {
+		printf(TNAME " Error in open(), errno: %d, %s\n", errno, strerror(errno));
+		exit(PTS_UNRESOLVED);
+	}
+	errno = 0;
+	read(test_fd, r_ptr, sizeof(r_val));
+	if (errno != 0)
+		printf(TNAME " Read operation is not allowed on file\n");
+	else {
+		printf(TNAME " Error, read operation is allowed on file \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+	errno = 0;
+	ret = write(test_fd, r_ptr, sizeof(r_val));
+	if (errno == 0 && ret > 0) {
+		printf(TNAME " Success, write operation allowed on file\n");
+		remove_file(filename_p);
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Error, write operation is not allowed on file \n");
+		remove_file(filename_p);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/open/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/open/assertions.xml
@@ -1,0 +1,220 @@
+<assertions>
+	<assertion id="1" tag="ref:XBD7:46754:46754">
+		Establish the connection between file and file descriptor.
+	</assertion>
+	<assertion id="2" tag="ref:XBD7:46759:46760">
+		When file is opened using open(), file descriptor shall not
+		share with any other process with in the system.
+	</assertion>
+	<assertion id="3" tag="ref:XBD7:46760:46761">
+		FD_CLOEXEC file descriptor flag associated with the new file descriptor
+		shall be cleared unless the O_CLOEXEC flag is set in oflag.
+	</assertion>
+	<assertion id="4" tag="ref:XBD6:46763:46764">
+		The file offset used to mark the current position within the file shall
+		be set to the beginning of the file.
+	</assertion>
+	<assertion id="5" tag="ref:XBD7:46770:46771">
+		When O_EXEC flag is used, file is opened for execute only.
+	</assertion>
+	<assertion id="6" tag="ref:XBD7:46772:46772">
+		When O_RDONLY flag is used, file is opened for read only.
+	</assertion>
+	<assertion id="7" tag="ref:XBD7:46773:46774">
+		When O_RDWR flag is used, file is opened for read and write.
+	</assertion>
+	<assertion id="8" tag="ref:XBD7:46775:46776">
+		When O_SEARCH flag is used, directory is opened for search only.
+	</assertion>
+	<assertion id="9" tag="ref:XBD7:46777:46777">
+		When O_WRONLY flag is used, file is opened for write only.
+	</assertion>
+	<assertion id="10" tag="ref:XBD7:46779:46779">
+		When O_APPEND flag is used, the file offset shall be set to the end of
+		the file prior to each write
+	</assertion>
+	<assertion id="11" tag="ref:XBD7:46781:46782">
+		When O_CREAT flag is set and O_DIRECTORY flag is not set, the file shall
+		be created as regular file.
+	</assertion>
+	<assertion id="12" tag="ref:XBD7:46783:46784">
+		When O_CREAT flag is set, the user ID of the file which is created,
+		shall be set to the effective user ID of the process.
+	</assertion>
+	<assertion id="13" tag="ref:XBD7:46784:46785">
+		When O_CREAT flag is set, the group ID of the file which is created shall
+		be set to the group ID of the file’s parent directory.
+	</assertion>
+	<assertion id="14" tag="ref:XBD7:46786:46792">
+		When O_CREAT flag is set, permission bits for the file mode which is
+		created shall be set as (mode_t & ~umask), where mode_t is user argument
+		which is passed after oflag.
+	</assertion>
+	<assertion id="15" tag="ref:XBD7:46799:46799">
+		When O_DIRECTORY flag and O_CREAT flag are set, new directory will be
+		created if not already exist.
+	</assertion>
+	<assertion id="16" tag="ref:XBD7:46799:46799">
+		When O_DIRECTORY flag is set on non directory file, call will fail and
+		set errno to [ENOTDIR]
+	</assertion>
+	<assertion id="17" tag="ref:XBD7:46800:46801">
+		When O_DSYNC flag is set, Write I/O operations on the file descriptor
+		shall complete as defined by synchronized I/O data integrity completion
+	</assertion>
+	<assertion id="18" tag="ref:XBD7:46802:46803">
+		When O_CREAT and O_EXCL are set, open( ) shall fail if the file exists
+		and errno will be set EEXIST.
+	</assertion>
+	<assertion id="19" tag="ref:XBD7:46803:46806">
+		When O_CREAT and O_EXCL are set, check for the existence of the file and
+		the creation of the file if it does not exist shall be atomic with respect
+		to other threads executing open( ) naming the same filename in the same
+		directory with O_EXCL and O_CREAT set.
+	</assertion>
+	<assertion id="20" tag="ref:XBD7:46807:46809">
+		When O_EXCL and O_CREAT are set, and path names a symbolic link, open( )
+		shall fail and set errno to [EEXIST], regardless of the contents of the symbolic link.
+	</assertion>
+	<assertion id="21" tag="ref:XBD7:46810:46811">
+		When O_NOCTTY is set and path identifies a terminal device, open( )
+		shall not cause the terminal device to become the controlling terminal for the process.
+	</assertion>
+	<assertion id="22" tag="ref:XBD7:46811:46812">
+		When O_NOCTTY is set and if path does not identify a terminal device,
+		O_NOCTTY shall be ignored.
+	</assertion>
+	<assertion id="23" tag="ref:XBD7:46813:46813">
+		When O_NOFOLLOW is set and If pathname is a symbolic link, then the
+		open fail and set errno to [ELOOP]
+	</assertion>
+	<assertion id="24" tag="ref:XBD7:46814:46815">
+		When opening a FIFO with O_RDONLY set and If O_NONBLOCK is set, an
+		open( ) for reading-only shall return without delay.
+	</assertion>
+	<assertion id="25" tag="ref:XBD7:46816:46817">
+		When opening a FIFO with O_WRONLY set and if O_NONBLOCK is set, open( )
+		for writing-only shall return an error if no process currently has the file open for reading.
+	</assertion>
+	<assertion id="26" tag="ref:XBD7:46817:46818">
+		When opening a FIFO with O_RDONLY set and If O_NONBLOCK is not set, an
+		open( ) for reading-only shall block the calling thread until a thread opens the file for writing
+	</assertion>
+	<assertion id="27" tag="ref:XBD7:46818:46819">
+		When opening a FIFO with O_WRONLY set and if O_NONBLOCK is not set,
+		open( ) for writing-only shall block the calling thread until a thread opens the file for reading.
+	</assertion>
+	<assertion id="28" tag="ref:XBD7:46822:46824">
+		When opening a block special or character special files which
+		supports non blocking opens with O_NONBLOCK set, the open( ) function
+		shall return without blocking for the device to be ready or available.
+	</assertion>
+	<assertion id="29" tag="ref:XBD7:46825:46828">
+		When opening a block special or character special files which supports
+		non blocking opens with O_NONBLOCK not set, the open( ) function shall block
+		the calling thread until the device is ready or available before returning.
+	</assertion>
+	<assertion id="30" tag="ref:XBD7:46843:46844">
+		When O_TRUNC flag is set and If the file already exists and is a regular file and the access
+		mode allows writing (i.e., is O_RDWR or O_WRONLY) it will be truncated to length 0.
+	</assertion>
+	<assertion id="31" tag="ref:XBD7:46845:46846">
+		When the file is a FIFO or terminal device file, the O_TRUNC flag is ignored.
+	</assertion>
+	<assertion id="32" tag="ref:XBD7:">
+		If path identifies a terminal device other than a pseudo-terminal, the
+		device is not already open in any process, and either O_TTY_INIT is set in
+		oflag or O_TTY_INIT has the value zero, open( ) shall set any non-standard
+		termios structure terminal parameters to a state that provides conforming behavior.
+	</assertion>
+	<assertion id="33" tag="ref:XBD7:46860:46861">
+		When O_CREAT is set and the file did not previously exist, upon successful
+		completion, open( ) shall mark for update the last data access, last data
+		modification, and last file status change timestamps of the file and the last
+		data modification and last file status change timestamps of the parent directory.
+	</assertion>
+	<assertion id="34" tag="ref:XBD7:46866:46867">
+		When O_TRUNC is set and the file did previously exist, upon successful completion, open( ) shall
+		mark for update the last data modification and last file status change timestamps of the file.
+	</assertion>
+	<assertion id="35" tag="ref:XBD7:46880:46881">
+		The largest value that can be represented correctly in an object of type off_t shall be established
+		as the offset maximum in the open file description.
+	</assertion>
+	<assertion id="36" tag="ref:XBD7:46899:46899">
+		When search permission is denied on a component of the path prefix, errno will be set to EACCES.
+	</assertion>
+	<assertion id="37" tag="ref:XBD7:46900:46900">
+		When the file exists and permission specified by oflag are denied, errno will be set to EACCES.
+	</assertion>
+	<assertion id="38" tag="ref:XBD7:46901:46901">
+		When the file does not exist and write permission are denied on directory, errno will be set to EACCES.
+	</assertion>
+	<assertion id="39" tag="ref:XBD7:46902:46902">
+		When O_TRUNC is set and write permission is denied, errno will be set to EACCES.
+	</assertion>
+	<assertion id="40" tag="ref:XBD7:46904:46904">
+		When a signal was caught during open(), errno will be set to EINTR.
+	</assertion>
+	<assertion id="41" tag="ref:XBD7:46905:46905">
+		When O_DSYNC is set and synchronized I/O is not supported on the file, errno will be set to  EINVAL.
+	</assertion>
+	<assertion id="42" tag="ref:XBD7:46906:46907">
+		When the path argument names a STREAMS file and a hangup or error occurred during the open( ), errno will be set EIO.
+	</assertion>
+	<assertion id="43" tag="ref:XBD7:46908:46909">
+		When the named file is a directory and oflag includes O_WRONLY or O_RDWR, or
+		includes O_CREAT without O_DIRECTORY, errno will be set to EISDIR.
+	</assertion>
+	<assertion id="44" tag="ref:XBD7:46910:46911">
+		When a loop exists in symbolic links encountered during resolution of the path argument, errno will be set to ELOOP.
+	</assertion>
+	<assertion id="45" tag="ref:XBD7:46913:46913">
+		When all file descriptors available to the process are currently open, errno will be set EMFILE.
+	</assertion>
+	<assertion id="47" tag="ref:XBD7:46914:46915">
+		When the length of a component of a pathname is longer than {NAME_MAX}, errno will be set to ENAMETOOLONG.
+	</assertion>
+	<assertion id="46" tag="ref:XBD7:46916:46916">
+		When the maximum allowable number of files is currently open in the system, errno will be set to ENFILE
+	</assertion>
+	<assertion id="47" tag="ref:XBD7:46917:46917">
+		When O_CREAT is not set and a component of path does not name an existing file, errno will be set to ENOENT.
+	</assertion>
+	<assertion id="48" tag="ref:XBD7:46918:46919">
+		When O_CREAT is set and a component of the path prefix of path does not name an existing file,
+		or path points to an empty string, errno will be set to ENOENT.
+	</assertion>
+	<assertion id="49" tag="ref:XBD7:46920:46922">
+		When O_CREAT is set, and the path argument contains at least one non-slash character
+		and ends with one or more trailing slash characters, errno will be set to ENOTDIR.
+	</assertion>
+	<assertion id="50" tag="ref:XBD7:46923:46924">
+		When O_CREAT flag is set and If the path without the trailing slash characters would
+		name an existing file, an [ENOENT] error shall not occur.
+	</assertion>
+	<assertion id="51" tag="ref:XBD7:46925:46926">
+		When the path argument names a STREAMS-based file and the system is unable to allocate a STREAM,
+		errno will be set to ENOSR.
+	</assertion>
+	<assertion id="52" tag="ref:XBD7:46927:46928">
+		When the directory or file system that would contain the new file cannot be expanded,
+		the file does not exist, and O_CREAT is specified, errno will be set to ENOSPC.
+	</assertion>
+	<assertion id="53" tag="ref:XBD7:46936:46937">
+		When O_NONBLOCK is set, the named file is a FIFO, O_WRONLY is set, and no process has the file open for reading,
+		errno will be set to ENXIO.
+	</assertion>
+	<assertion id="54" tag="ref:XBD7:46938:46939">
+		When the named file is a character special or block special file, and the device associated with this special file
+		does not exist, errno will be set to ENXIO
+	</assertion>
+	<assertion id="55" tag="ref:XBD7:46940:46941">
+		When the named file is a regular file and the size of the file cannot be represented correctly in an object of
+		type off_t, errno will be set to EOVERFLOW
+	</assertion>
+	<assertion id="56" tag="ref:XBD7:46942:46944">
+		When the named file resides on a read-only file system and either O_WRONLY, O_RDWR,
+		O_CREAT (if the file does not exist), or O_TRUNC is set in the oflag argument, errno will be set to EROFS
+	</assertion>
+</assertions>


### PR DESCRIPTION
Adding assertions.xml and initial set of tests for open() api.

Signed-off-by: Palleti, Avinash Reddy <avinash.reddy.palleti@intel.com>
Change-Id: I7262497df1251d7d87a74ae8da954cf1842f1cb7