### PR TITLE
Modify type to avoid overflows

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_timedrdlock/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_timedrdlock/2-1.c
@@ -43,7 +43,7 @@
 
 static pthread_rwlock_t rwlock;
 static int thread_state;
-static int currsec1, currsec2;
+static time_t currsec1, currsec2;
 static int expired;
 
 static void *fn_rd(void *arg)

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_timedrdlock/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_timedrdlock/5-1.c
@@ -35,7 +35,7 @@
 
 #define TIMEOUT 1
 static int thread_state;
-static int currsec1;
+static time_t currsec1;
 static int expired;
 
 static void *fn_rd_1(void *arg)


### PR DESCRIPTION
time_t value returns a 64 bit value, and therefore will overflow when casted to integer (year 2038 problem). In order to avoid integer overflow, the values should be stored to type time_t (signed 64 bit).

Signed-off-by: Keita Suzuki <keitasuzuki.park@sslab.ics.keio.ac.jp>
711d6c9