### PR TITLE
network/stress: fix sending igmp query pkt too ofen cause test fail

### DIFF
--- a/testcases/network/stress/ns-tools/ns-igmp_querier.c
+++ b/testcases/network/stress/ns-tools/ns-igmp_querier.c
@@ -433,6 +433,11 @@ void send_query(struct igmp_info *info_p)
 				(struct sockaddr *)&to,
 				sizeof(struct sockaddr_in));
 		if (retval != query_size) {
+			if (errno == ENOBUFS) {
+				sleep(1);
+				continue;
+			}
+			
 			if (catch_sighup)
 				break;
 			else


### PR DESCRIPTION
igmp querying may fail if there aren't enough input buffers or the output queue is full. Wait 1 second if `sendto(..)` fails with `ENOBUFS`, then try again.

Signed-off-by: supersojo <suyanjun218@163.com>