### PR TITLE
Address simple -Wunused variable issues with `argc`/`argv`

### DIFF
--- a/testcases/open_posix_testsuite/functional/mqueues/send_rev_1.c
+++ b/testcases/open_posix_testsuite/functional/mqueues/send_rev_1.c
@@ -25,7 +25,7 @@
 #define MSG_SIZE	128
 #define MAX_MSG		3
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	struct mq_attr mqstat, attr;
 	char r_msg_ptr[MAX_MSG][MSG_SIZE];

--- a/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c
+++ b/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c
@@ -105,7 +105,7 @@ int *receive_2(void *mq)
 	pthread_exit(NULL);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 
 	mqd_t mq1 = 0, mq2 = 0;

--- a/testcases/open_posix_testsuite/functional/semaphores/sem_conpro.c
+++ b/testcases/open_posix_testsuite/functional/semaphores/sem_conpro.c
@@ -94,7 +94,7 @@ int *consumer(buf_t * buf)
 	pthread_exit(0);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	int shared = 1;
 	int occupied_value = BUF_SIZE;

--- a/testcases/open_posix_testsuite/functional/semaphores/sem_philosopher.c
+++ b/testcases/open_posix_testsuite/functional/semaphores/sem_philosopher.c
@@ -114,7 +114,7 @@ int philosopher(void *ID)
 	pthread_exit(NULL);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	pthread_t phi[PH_NUM];
 	int PhID[PH_NUM];

--- a/testcases/open_posix_testsuite/functional/semaphores/sem_readerwriter.c
+++ b/testcases/open_posix_testsuite/functional/semaphores/sem_readerwriter.c
@@ -105,7 +105,7 @@ int *writer(void *ID)
 	pthread_exit(NULL);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	pthread_t rea[READ_NUM], wri[WRITE_NUM];
 	int ReadID[READ_NUM], WriteID[WRITE_NUM];

--- a/testcases/open_posix_testsuite/functional/semaphores/sem_sleepingbarber.c
+++ b/testcases/open_posix_testsuite/functional/semaphores/sem_sleepingbarber.c
@@ -135,7 +135,7 @@ void *customers(void *ID)
 	return NULL;
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	pthread_t bar, cus[CUS_NUM];
 	int shared = 0;


### PR DESCRIPTION
This unfortunately can't be done with some other variables without first
rewriting/refactoring code and how it is compiled to ensure that the
logic functions as expected.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>