### PR TITLE
Fix `mounted_noatime` on *BSD

### DIFF
--- a/testcases/open_posix_testsuite/include/noatime.h
+++ b/testcases/open_posix_testsuite/include/noatime.h
@@ -79,7 +79,7 @@ int mounted_noatime(const char *path)
 	struct statfs _statfs;
 
 	if (statfs(path, &_statfs) == -1) {
-		printf("statfs for %s failed: %s", strerror(errno));
+		printf("statfs for %s failed: %s", path, strerror(errno));
 		return -1;
 	}
 


### PR DESCRIPTION
I accidentally omitted one of the arguments to a diagnostic printf I
added when I originally added the code. This addresses the issue by
adding the argument for the `path` parameter to the printf call to add
the diagnostics output I originally intended to add.

This does not affect Linux.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>