### PR TITLE
Use nanosleep instead of usleep in tests

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/1-1.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -38,6 +39,7 @@ int main(void)
 	char tmpfname[256];
 #define BUF_SIZE 1024
 	char buf[BUF_SIZE];
+	struct timespec processing_completion_ts = {0, 10000000};
 	int fd, err;
 	struct aiocb aiocb;
 
@@ -72,7 +74,7 @@ int main(void)
 		return PTS_FAIL;
 	case AIO_NOTCANCELED:
 		do {
-			usleep(10000);
+			nanosleep(&processing_completion_ts, NULL);
 			err = aio_error(&aiocb);
 		} while (err == EINPROGRESS);
 	}

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/2-1.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -77,7 +78,8 @@ int main(void)
 		return PTS_FAIL;
 	case AIO_NOTCANCELED:
 		do {
-			usleep(10000);
+			struct timespec completion_wait_ts = {0, 10000000};
+			nanosleep(&completion_wait_ts, NULL);
 			err = aio_error(&aiocb);
 		} while (err == EINPROGRESS);
 	}

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/3-1.c
@@ -37,6 +37,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -67,6 +68,7 @@ int main(void)
 	struct aiocb *aiocb_list[BUF_NB];
 	struct aiocb *aiocb;
 	struct sigaction action;
+	struct timespec processing_completion_ts = {0, 10000000};
 	int i;
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L) {
@@ -144,7 +146,7 @@ int main(void)
 	close(fd);
 
 	while (countdown)
-		usleep(10000);
+		nanosleep(&processing_completion_ts, NULL);
 
 	if (!canceled)
 		return PTS_UNRESOLVED;

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/8-1.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -43,6 +44,7 @@ int main(void)
 	int fd;
 	int ret;
 	struct aiocb aiocb;
+	struct timespec processing_completion_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -70,7 +72,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&processing_completion_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_error/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_error/1-1.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -40,6 +41,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	int fd, ret;
 	struct aiocb aiocb;
+	struct timespec processing_completion_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -67,7 +69,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&processing_completion_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 	if (ret != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/14-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/14-1.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec aio_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -55,7 +57,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_write);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/2-1.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int fd, ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec processing_completion_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -64,7 +66,7 @@ int main(void)
 
 	/* wait for aio_fsync */
 	do {
-		usleep(10000);
+		nanosleep(&processing_completion_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/3-1.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int fd, ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec aio_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -63,7 +65,7 @@ int main(void)
 	}
 	/* wait for aio_fsync */
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/4-1.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -64,7 +65,8 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		struct timespec completion_wait_ts = {0, 10000000};
+		nanosleep(&completion_wait_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/5-1.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -30,6 +31,7 @@ int main(void)
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 	int ret, err;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -71,7 +73,7 @@ int main(void)
 	 * something else otherwise test hangs
 	 */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb_fsync);
 	} while (err == EINPROGRESS);
 	if (err < 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-1.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec aio_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -55,7 +57,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_write);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {
@@ -74,7 +76,7 @@ int main(void)
 
 	/* wait for aio_fsync */
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-2.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec aio_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -55,7 +57,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_write);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {
@@ -74,7 +76,7 @@ int main(void)
 
 	/* wait for aio_fsync */
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-3.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec aio_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -55,7 +57,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_write);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {
@@ -74,7 +76,7 @@ int main(void)
 
 	/* wait for aio_fsync */
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/8-4.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec aio_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -55,7 +57,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_write);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {
@@ -74,7 +76,7 @@ int main(void)
 
 	/* wait for aio_fsync */
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_fsync/9-1.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -29,6 +30,7 @@ int main(void)
 	int ret;
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
+	struct timespec aio_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -55,7 +57,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_write);
 	} while (ret == EINPROGRESS);
 	if (ret < 0) {
@@ -73,7 +75,7 @@ int main(void)
 
 	/* wait for aio_fsync */
 	do {
-		usleep(10000);
+		nanosleep(&aio_wait_ts, NULL);
 		ret = aio_error(&aiocb_fsync);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/1-1.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "posixtest.h"
@@ -44,6 +45,7 @@ int main(void)
 	int ret;
 
 	struct aiocb aiocb;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -81,7 +83,7 @@ int main(void)
 
 	/* Wait until end of transaction */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/10-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/10-1.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -40,6 +41,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 	int ret = 0;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -61,7 +63,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 	if (ret != EBADF) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/11-1.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -69,9 +70,10 @@ int main(void)
 	aiocb.aio_nbytes = BUF_SIZE;
 
 	if (aio_read(&aiocb) != -1) {
+		struct timespec completion_wait_ts = {0, 10000000};
 		int err;
 		do {
-			usleep(10000);
+			nanosleep(&completion_wait_ts, NULL);
 			err = aio_error(&aiocb);
 		} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/3-1.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -40,6 +41,7 @@ int main(void)
 	int fd;
 	int ret;
 	struct aiocb aiocb;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -72,7 +74,7 @@ int main(void)
 
 	/* Wait for request completion */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/3-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/3-2.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -40,6 +41,7 @@ int main(void)
 	int fd;
 	int ret;
 	struct aiocb aiocb;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -74,7 +76,7 @@ int main(void)
 
 	/* Wait for request completion */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/4-1.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -41,6 +42,7 @@ int main(void)
 	int fd;
 	struct aiocb aiocb;
 	int i;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -81,7 +83,7 @@ int main(void)
 
 	/* Wait until end of transaction */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/5-1.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -42,6 +43,7 @@ int main(void)
 	int fd;
 	struct aiocb aiocb;
 	int i;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -82,7 +84,7 @@ int main(void)
 
 	/* Wait until end of transaction */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_read/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_read/7-1.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -41,6 +42,7 @@ int main(void)
 	int fd;
 	int ret;
 	struct aiocb aiocb;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -68,7 +70,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_return/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_return/1-1.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -41,6 +42,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 	int fd, retval;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -70,7 +72,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		retval = aio_error(&aiocb);
 	} while (retval == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_return/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_return/2-1.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "posixtest.h"
+#include <time.h>
 
 #define TNAME "aio_return/2-1.c"
 #define BUF_SIZE 111
@@ -39,6 +40,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 	int fd, retval;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -69,7 +71,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		retval = aio_error(&aiocb);
 	} while (retval == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_return/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_return/3-1.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -44,6 +45,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 	int fd, retval;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -74,7 +76,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		retval = aio_error(&aiocb);
 	} while (retval == EINPROGRESS);
 
@@ -100,7 +102,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		retval = aio_error(&aiocb);
 	} while (retval == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_return/3-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_return/3-2.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -42,6 +43,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 	int fd, retval;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -72,7 +74,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		retval = aio_error(&aiocb);
 	} while (retval == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_return/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_return/4-1.c
@@ -29,7 +29,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
+
 #include "posixtest.h"
 
 #define TNAME "aio_return/4-1.c"
@@ -42,6 +44,7 @@ int main(void)
 	struct aiocb aiocb;
 	struct aiocb aiocb2;
 	int fd, retval;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -71,7 +74,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		retval = aio_error(&aiocb);
 	} while (retval == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/3-1.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 #include <aio.h>
 
 #include "posixtest.h"
@@ -44,6 +45,7 @@ int main(void)
 	int fd;
 	struct aiocb aiocb[NAIOCB];
 	const struct aiocb *list[NENT];
+	struct timespec processing_completion_ts = {0, 10000000};
 	int i;
 	int ret;
 
@@ -87,7 +89,7 @@ int main(void)
 
 	for (i = 0; i < NAIOCB; ++i) {
 		do {
-			usleep(10000);
+			nanosleep(&processing_completion_ts, NULL);
 			ret = aio_error(&aiocb[i]);
 		} while (ret == EINPROGRESS);
 		if (aio_return(&aiocb[i]) == -1) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/4-1.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "posixtest.h"
@@ -68,6 +69,7 @@ int main(void)
 	struct timespec ts = {0, 10};
 	int errors = 0;
 	int ret, err, i, rval, fd;
+	struct timespec processing_completion_ts = {0, 50000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -184,7 +186,7 @@ int main(void)
 
 	/* Wait for list processing completion */
 	while (!received_all && retries-- > 0)
-		usleep(50000);
+		nanosleep(&processing_completion_ts, NULL);
 
 	if (retries <= 0) {
 		printf(TNAME " timeouted while waiting for I/O completion");

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/9-1.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "posixtest.h"
@@ -47,6 +48,7 @@ static void sigrt1_handler()
 
 static int do_test(int num_aiocbs, size_t buf_size)
 {
+	struct timespec processing_completion_ts = {0, 10000000};
 	char tmpfname[256];
 	int fd;
 	struct aiocb *aiocbs[num_aiocbs];
@@ -160,7 +162,7 @@ static int do_test(int num_aiocbs, size_t buf_size)
 
 	/* Wait for list processing completion */
 	while (!received_all)
-		usleep(10000);
+		nanosleep(&processing_completion_ts, NULL);
 
 	/* Check return values and errors */
 	err = PTS_PASS;
@@ -178,7 +180,7 @@ static int do_test(int num_aiocbs, size_t buf_size)
 
 err4:
 	while (!received_all)
-		usleep(10000);
+		nanosleep(&processing_completion_ts, NULL);
 err3:
 	for (i = 0; i < num_aiocbs; i++)
 		free(aiocbs[i]);

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/1-1.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -45,6 +46,7 @@ int main(void)
 	struct aiocb aiocb;
 	int err;
 	int ret;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -74,7 +76,7 @@ int main(void)
 
 	/* Wait until completion */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/1-2.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -46,6 +47,7 @@ int main(void)
 	struct aiocb aiocb;
 	int err;
 	int ret;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -87,7 +89,7 @@ int main(void)
 
 	/* Wait until end of transaction */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/2-1.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -53,6 +54,7 @@ int main(void)
 	int i;
 	int err;
 	int ret;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -86,7 +88,7 @@ int main(void)
 
 	/* Wait until completion */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb[2]);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/3-1.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -45,6 +46,7 @@ int main(void)
 	struct aiocb aiocb;
 	int err;
 	int ret;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -74,7 +76,7 @@ int main(void)
 
 	/* Wait until completion */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/5-1.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <aio.h>
+#include <time.h>
 
 #include "posixtest.h"
 
@@ -43,6 +44,7 @@ int main(void)
 	struct aiocb aiocb;
 	int err;
 	int ret;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -70,7 +72,7 @@ int main(void)
 
 	/* Wait until completion */
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		err = aio_error(&aiocb);
 	} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/8-1.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 #include <aio.h>
 
 #include "posixtest.h"
@@ -40,6 +41,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 	int ret = 0;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -61,7 +63,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/8-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/8-2.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 #include <aio.h>
 
 #include "posixtest.h"
@@ -42,6 +43,7 @@ int main(void)
 	int fd;
 	struct aiocb aiocb;
 	int ret = 0;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -74,7 +76,7 @@ int main(void)
 	}
 
 	do {
-		usleep(10000);
+		nanosleep(&completion_wait_ts, NULL);
 		ret = aio_error(&aiocb);
 	} while (ret == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/9-1.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 #include <aio.h>
 
 #include "posixtest.h"
@@ -44,6 +45,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	int fd;
 	struct aiocb aiocb;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -68,7 +70,7 @@ int main(void)
 	if (aio_write(&aiocb) != -1) {
 		int err;
 		do {
-			usleep(10000);
+			nanosleep(&completion_wait_ts, NULL);
 			err = aio_error(&aiocb);
 		} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/9-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/9-2.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 #include <aio.h>
 
 #include "posixtest.h"
@@ -44,6 +45,7 @@ int main(void)
 	char buf[BUF_SIZE];
 	int fd;
 	struct aiocb aiocb;
+	struct timespec completion_wait_ts = {0, 10000000};
 
 	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
 		return PTS_UNSUPPORTED;
@@ -68,7 +70,7 @@ int main(void)
 	if (aio_write(&aiocb) != -1) {
 		int err;
 		do {
-			usleep(10000);
+			nanosleep(&completion_wait_ts, NULL);
 			err = aio_error(&aiocb);
 		} while (err == EINPROGRESS);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/12-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/12-1.c
@@ -148,12 +148,13 @@ int main(void)
 	if (ret != 0 && ret != PTHREAD_BARRIER_SERIAL_THREAD)
 		error_and_exit(ret, "pthread_barrier_wait start");
 
+	struct timespec completion_wait_ts = {0, SIGNAL_DELAY_MS*1000000};
 	while (i < TIMEOUT*1000 && mq_timedsend_errno < 0) {
 		/* signal thread while it's in mq_timedsend */
 		ret = pthread_kill(new_th, SIGUSR1);
 		if (ret != 0)
 			error_and_exit(ret, "pthread_kill");
-		usleep(SIGNAL_DELAY_MS*1000);
+		nanosleep(&completion_wait_ts, NULL);
 		i += SIGNAL_DELAY_MS;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cancel/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cancel/3-1.c
@@ -28,8 +28,9 @@ static sem_t sem;
 
 static void cleanup_func(LTP_ATTRIBUTE_UNUSED void *unused)
 {
+	struct timespec cleanup_ts = {0, SLEEP_MS*1000000};
 	do {
-		usleep(SLEEP_MS*1000);
+		nanosleep(&cleanup_ts, NULL);
 		thread_sleep_time += SLEEP_MS;
 	} while (after_cancel == 0 && thread_sleep_time < TIMEOUT_MS);
 }
@@ -37,13 +38,14 @@ static void cleanup_func(LTP_ATTRIBUTE_UNUSED void *unused)
 static void *thread_func(LTP_ATTRIBUTE_UNUSED void *unused)
 {
 	int waited_for_cancel_ms = 0;
+	struct timespec cancel_wait_ts = {0, SLEEP_MS*1000000};
 
 	SAFE_PFUNC(pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL));
 	pthread_cleanup_push(cleanup_func, NULL);
 
 	SAFE_FUNC(sem_post(&sem));
 	while (waited_for_cancel_ms < TIMEOUT_MS) {
-		usleep(SLEEP_MS*1000);
+		nanosleep(&cancel_wait_ts, NULL);
 		waited_for_cancel_ms += SLEEP_MS;
 	}
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/1-1.c
@@ -63,6 +63,7 @@ static void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i, rc;
 	pthread_t thread[THREAD_NUM];
 
@@ -83,7 +84,7 @@ int main(void)
 	}
 
 	while (start_num < THREAD_NUM)
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	/*
 	 * Acquire the mutex to make sure that all waiters are currently

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/2-1.c
@@ -72,6 +72,7 @@ static void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i, rc;
 	pthread_t thread[THREAD_NUM];
 
@@ -91,7 +92,7 @@ int main(void)
 		}
 	}
 	while (start_num < THREAD_NUM)
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	/* Acquire the mutex to make sure that all waiters are currently
 	   blocked on pthread_cond_wait */

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/2-2.c
@@ -85,6 +85,7 @@ static void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i, rc;
 	pthread_t thread[THREAD_NUM];
 
@@ -104,7 +105,7 @@ int main(void)
 		}
 	}
 	while (start_num < THREAD_NUM)
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	if (pthread_mutex_lock(&td.mutex) != 0) {
 		fprintf(stderr, "Main: Fail to acquire mutex\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/4-1.c
@@ -61,6 +61,7 @@ static void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i, rc;
 	pthread_t thread[THREAD_NUM];
 
@@ -80,7 +81,7 @@ int main(void)
 		}
 	}
 	while (start_num < THREAD_NUM)
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	/* Acquire the mutex to make sure that all waiters are currently
 	   blocked on pthread_cond_wait */

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/1-1.c
@@ -79,6 +79,7 @@ void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i, rc;
 	struct sigaction act;
 
@@ -98,7 +99,7 @@ int main(void)
 		}
 	}
 	while (start_num < THREAD_NUM)	/* waiting for all threads started */
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	/* Acquire the mutex to make sure that all waiters are currently
 	   blocked on pthread_cond_wait */
@@ -147,7 +148,7 @@ int main(void)
 				"Main failed to signal the condition\n");
 			exit(PTS_UNRESOLVED);
 		}
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 	}
 
 	/* join all secondary threads */

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c
@@ -96,6 +96,7 @@ void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i;
 	struct sigaction act;
 	pthread_mutexattr_t ma;
@@ -125,7 +126,7 @@ int main(void)
 		}
 	}
 	while (start_num < THREAD_NUM)	/* waiting for all threads started */
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	sleep(1);
 
@@ -143,7 +144,7 @@ int main(void)
 				"Main failed to signal the condition\n");
 			return PTS_UNRESOLVED;
 		}
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 	}
 
 	for (i = 0; i < THREAD_NUM; i++) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-2.c
@@ -95,6 +95,7 @@ void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i;
 	pthread_t thread[THREAD_NUM];
 	pthread_mutexattr_t ma;
@@ -124,7 +125,7 @@ int main(void)
 		}
 	}
 	while (start_num < THREAD_NUM)	/* waiting for all threads started */
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	sleep(1);
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c
@@ -75,6 +75,7 @@ void *thr_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	int i, rc;
 	struct sigaction act;
 
@@ -94,7 +95,7 @@ int main(void)
 		}
 	}
 	while (start_num < THREAD_NUM)	/* waiting for all threads started */
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	/* Setup alarm handler */
 	act.sa_handler = alarm_handler;
@@ -114,7 +115,7 @@ int main(void)
 			printf("Test FAILED\n");
 			exit(PTS_FAIL);
 		}
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 	}
 
 	for (i = 0; i < THREAD_NUM; i++) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/1-1.c
@@ -79,6 +79,7 @@ void *t1_func(void *arg)
 int main(void)
 {
 	pthread_t thread1;
+	struct timespec thread_start_ts = {0, 100000};
 
 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
 		fprintf(stderr, "Fail to initialize mutex\n");
@@ -94,7 +95,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 	while (!t1_start)	/* wait for thread1 started */
-		usleep(100);
+		nanosleep(&thread_start_ts, NULL);
 
 	/* acquire the mutex released by pthread_cond_wait() within thread 1 */
 	if (pthread_mutex_lock(&td.mutex) != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-1.c
@@ -98,6 +98,7 @@ void *t1_func(void *arg)
 int main(void)
 {
 	pthread_t thread1;
+	struct timespec thread_start_ts = {0, 100000};
 
 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
 		fprintf(stderr, "Fail to initialize mutex\n");
@@ -113,7 +114,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 	while (!t1_start)	/* wait for thread1 started */
-		usleep(100);
+		nanosleep(&thread_start_ts, NULL);
 
 	/* acquire the mutex released by pthread_cond_wait() within thread 1 */
 	if (pthread_mutex_lock(&td.mutex) != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-2.c
@@ -78,6 +78,7 @@ int main(void)
 {
 	pthread_t thread1;
 	void *th_ret;
+	struct timespec thread_start_ts = {0, 100000};
 
 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
 		fprintf(stderr, "Fail to initialize mutex\n");
@@ -94,7 +95,7 @@ int main(void)
 	}
 
 	while (!t1_start)	/* wait for thread1 started */
-		usleep(100);
+		nanosleep(&thread_start_ts, NULL);
 
 	/* acquire the mutex released by pthread_cond_wait() within thread 1 */
 	if (pthread_mutex_lock(&td.mutex) != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-4.c
@@ -252,6 +252,7 @@ int main(void)
 	pthread_t child_th;
 
 	long pshared, monotonic, cs, mf;
+	struct timespec wait_timeout_ts = {0, 100000};
 
 	output_init();
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);
@@ -540,7 +541,7 @@ int main(void)
 			}
 
 			/* Let the child leave the wait function if something is broken */
-			usleep(100);
+			nanosleep(&wait_timeout_ts, NULL);
 
 			if (td->ctrl != 1) {
 				FAILED

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-6.c
@@ -199,6 +199,7 @@ int main(void)
 	pthread_t th;
 
 	long altclk_ok, pshared_ok;
+	struct timespec processing_completion_ts = {0, 100000};
 
 	struct {
 		char altclk;	/* Want to use alternative clock */
@@ -381,9 +382,7 @@ int main(void)
 		}
 
 		sched_yield();
-#ifndef WITHOUT_XOPEN
-		usleep(100);
-#endif
+		nanosleep(&processing_completion_ts, NULL);
 
 		ret = pthread_mutex_unlock(&(data.mtx));
 		if (ret != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/2-7.c
@@ -243,6 +243,7 @@ void *tf(void *arg)
 
 int main(void)
 {
+	struct timespec wait_ts;
 	int ret;
 	unsigned int i;
 	pthread_mutexattr_t ma;
@@ -258,6 +259,9 @@ int main(void)
 	pthread_t child_th;
 
 	long pshared, monotonic, cs, mf;
+
+	wait_ts.tv_sec = 0;
+	wait_ts.tv_nsec = TIMEOUT * 1000;
 
 	output_init();
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);
@@ -543,7 +547,7 @@ int main(void)
 #endif
 
 			/* Let the child leave the wait function if something is broken */
-			usleep(TIMEOUT);
+			nanosleep(&wait_ts, NULL);
 
 			if (td->ctrl != 1) {
 				FAILED

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/3-1.c
@@ -83,6 +83,7 @@ void *t1_func(void *arg)
 int main(void)
 {
 	pthread_t thread1;
+	struct timespec thread_start_ts = {0, 100000};
 
 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
 		fprintf(stderr, "Fail to initialize mutex\n");
@@ -98,7 +99,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 	while (!t1_start)	/* wait for thread1 started */
-		usleep(100);
+		nanosleep(&thread_start_ts, NULL);
 
 	/* acquire the mutex released by pthread_cond_wait() within thread 1 */
 	if (pthread_mutex_lock(&td.mutex) != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/1-1.c
@@ -66,6 +66,7 @@ void *t1_func(void *arg)
 
 int main(void)
 {
+	struct timespec completion_wait_ts = {0, 100000};
 	struct sigaction act;
 
 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
@@ -82,7 +83,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 	while (!t1_start)	/* wait for thread1 started */
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	/* acquire the mutex released by pthread_cond_wait() within thread 1 */
 	if (pthread_mutex_lock(&td.mutex) != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-1.c
@@ -79,7 +79,7 @@ void *t1_func(void *arg)
 
 int main(void)
 {
-
+	struct timespec completion_wait_ts = {0, 100000};
 	struct sigaction act;
 
 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
@@ -96,7 +96,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 	while (!t1_start)	/* wait for thread1 started */
-		usleep(100);
+		nanosleep(&completion_wait_ts, NULL);
 
 	/* acquire the mutex released by pthread_cond_wait() within thread 1 */
 	if (pthread_mutex_lock(&td.mutex) != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-2.c
@@ -266,6 +266,7 @@ int main(void)
 	pthread_t child_th;
 
 	long pshared, monotonic, cs, mf;
+	struct timespec wait_ts = {0, 100000};
 
 	output_init();
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);
@@ -547,6 +548,7 @@ int main(void)
 		}
 
 		if (td->ctrl == 1) {	/* The child is inside the cond wait */
+
 			ret = pthread_cond_signal(&(td->cnd));
 			if (ret != 0) {
 				UNRESOLVED(ret,
@@ -554,7 +556,7 @@ int main(void)
 			}
 
 			/* Let the child leave the wait function if something is broken */
-			usleep(100);
+			nanosleep(&wait_ts, NULL);
 
 			if (td->ctrl != 1) {
 				FAILED

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-3.c
@@ -283,6 +283,7 @@ int main(void)
 		UNRESOLVED(errno, "Unable to init sem B");
 	}
 
+	struct timespec wait_ts = {0, 100000};
 	for (i = 0; i < (sizeof(scenar) / sizeof(scenar[0])); i++) {
 #if VERBOSE > 1
 		output("Starting test for %s\n", scenar[i].descr);
@@ -382,9 +383,7 @@ int main(void)
 		}
 
 		sched_yield();
-#ifndef WITHOUT_XOPEN
-		usleep(100);
-#endif
+		nanosleep(&wait_ts, NULL);
 
 		ret = pthread_mutex_unlock(&(data.mtx));
 		if (ret != 0) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_create/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_create/3-1.c
@@ -71,8 +71,9 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
+	struct timespec thread_create_ts = {0, 10000000};
 	while (!sem)
-		usleep(10000);
+		nanosleep(&thread_create_ts, NULL);
 
 	ret = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 	if (ret) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_detach/4-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_detach/4-3.c
@@ -59,7 +59,7 @@ static sem_t semsig1;
 #endif
 
 static unsigned long count_sig;
-static unsigned long sleep_time;
+static long sleep_time;
 static sigset_t usersigs;
 
 struct thestruct {
@@ -82,6 +82,9 @@ static void *sendsig(void *arg)
 	struct thestruct *thearg = (struct thestruct *)arg;
 	int ret;
 	pid_t process;
+	struct timespec time_between_signals_ts;
+
+	time_between_signals_ts.tv_sec = 0;
 
 	process = getpid();
 
@@ -105,8 +108,11 @@ static void *sendsig(void *arg)
 		 * then start increasing sleep_time to make sure all threads
 		 * can progress */
 		sleep_time++;
-		if (sleep_time / SIGNALS_WITHOUT_DELAY > 0)
-			usleep(sleep_time / SIGNALS_WITHOUT_DELAY);
+		if (sleep_time / SIGNALS_WITHOUT_DELAY > 0) {
+			time_between_signals_ts.tv_nsec =
+			    (sleep_time * 1000) / SIGNALS_WITHOUT_DELAY;
+			nanosleep(&time_between_signals_ts, NULL);
+		}
 
 		ret = kill(process, thearg->sig);
 		if (ret != 0)

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_lock/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_lock/1-1.c
@@ -78,6 +78,8 @@ void *f1(void *parm)
 	/* Loopd M times to acquire the mutex, increase the value,
 	   and then release the mutex. */
 
+	struct timespec lock_wait_ts = {0, 1000000};
+
 	for (i = 0; i < LOOPS; ++i) {
 		rc = pthread_mutex_lock(&mutex);
 		if (rc != 0) {
@@ -89,7 +91,7 @@ void *f1(void *parm)
 		tmp = value;
 		tmp = tmp + 1;
 		fprintf(stderr, "Thread(0x%p) holds the mutex\n", (void *)self);
-		usleep(1000);	/* delay the increasement operation */
+		nanosleep(&lock_wait_ts, NULL);	/* delay the increasement operation */
 		value = tmp;
 
 		rc = pthread_mutex_unlock(&mutex);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_unlock/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_unlock/2-1.c
@@ -74,6 +74,8 @@ void *func(void *parm)
 	/* Loopd M times to acquire the mutex, increase the value,
 	   and then release the mutex. */
 
+	struct timespec lock_wait_ts = {0, 1000000};
+
 	for (i = 0; i < LOOPS; ++i) {
 		rc = pthread_mutex_lock(&mutex);
 		if (rc != 0) {
@@ -85,7 +87,7 @@ void *func(void *parm)
 		tmp = value;
 		tmp = tmp + 1;
 		fprintf(stderr, "Thread(0x%p) holds the mutex\n", (void *)self);
-		usleep(1000);	/* delay the increasement operation */
+		nanosleep(&lock_wait_ts, NULL);	/* delay the increasement operation */
 		value = tmp;
 
 		rc = pthread_mutex_unlock(&mutex);

--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_post/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_post/8-1.c
@@ -122,6 +122,7 @@ int main(void)
 	pid_t c_1, c_2, c_3, ret_pid;
 	int retval = PTS_UNRESOLVED;
 	int status;
+	struct timespec sync_wait_ts = {0, 100000};
 
 	snprintf(semname, sizeof(semname), "/" TEST "_%d", getpid());
 
@@ -182,11 +183,11 @@ int main(void)
 
 	/* Make sure the two children has been waiting */
 	do {
-		usleep(100);
+		nanosleep(&sync_wait_ts, NULL);
 		sem_getvalue(sem_1, &val);
 	} while (val != 1);
-	tst_process_state_wait3(c_1, 'S', 2000);
-	tst_process_state_wait3(c_2, 'S', 2000);
+	tst_process_state_wait3(c_1, 'S', 2);
+	tst_process_state_wait3(c_2, 'S', 2);
 
 	c_3 = fork();
 	switch (c_3) {
@@ -203,10 +204,10 @@ int main(void)
 
 	/* Make sure child 3 has been waiting for the lock */
 	do {
-		usleep(100);
+		nanosleep(&sync_wait_ts, NULL);
 		sem_getvalue(sem_1, &val);
 	} while (val != 0);
-	tst_process_state_wait3(c_3, 'S', 2000);
+	tst_process_state_wait3(c_3, 'S', 2);
 
 	/* Ok, let's release the lock */
 	fprintf(stderr, "P: release lock\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/sighold/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sighold/1-1.c
@@ -15,6 +15,7 @@
 
 #include <signal.h>
 #include <stdio.h>
+#include <time.h>
 #include <unistd.h>
 #include "posixtest.h"
 
@@ -28,6 +29,7 @@ static void handler(int signo)
 int main(void)
 {
 	struct sigaction act;
+	struct timespec signal_wait_ts = {0, 100000000};
 
 	act.sa_handler = handler;
 	act.sa_flags = 0;
@@ -50,7 +52,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
-	usleep(100000);
+	nanosleep(&signal_wait_ts, NULL);
 
 	if (handler_called) {
 		printf("FAIL: Signal was not blocked\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigrelse/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigrelse/1-1.c
@@ -19,6 +19,7 @@
 
 #include <signal.h>
 #include <stdio.h>
+#include <time.h>
 #include <unistd.h>
 #include "posixtest.h"
 
@@ -32,6 +33,7 @@ static void handler(int signo)
 int main(void)
 {
 	struct sigaction act;
+	struct timespec signal_wait_ts = {0, 100000000};
 
 	act.sa_handler = handler;
 	act.sa_flags = 0;
@@ -58,7 +60,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
-	usleep(100000);
+	nanosleep(&signal_wait_ts, NULL);
 
 	if (handler_called) {
 		printf("Test PASSED: SIGABRT removed from signal mask\n");

--- a/testcases/open_posix_testsuite/include/proc.h
+++ b/testcases/open_posix_testsuite/include/proc.h
@@ -11,19 +11,26 @@
  * the GNU General Public License for more details.
  */
 
+#include <time.h>
+
 #ifdef __linux__
 # include <errno.h>
 # include <string.h>
+
 int tst_process_state_wait3(pid_t pid, const char state,
-	unsigned long maxwait_ms)
+	long maxwait_s)
 {
 	char proc_path[128], cur_state;
 	int wait_step_ms = 10;
-	unsigned long waited_ms = 0;
+	struct timespec wait_step_ts;
+	long iteration, max_iterations = (maxwait_s * 1000) / wait_step_ms;
+
+	wait_step_ts.tv_sec = 0;
+	wait_step_ts.tv_nsec = wait_step_ms * 1000000;
 
 	snprintf(proc_path, sizeof(proc_path), "/proc/%i/stat", pid);
 
-	for (;;) {
+	for (iteration = 0; iteration < max_iterations; iteration++) {
 		FILE *f = fopen(proc_path, "r");
 
 		if (!f) {
@@ -43,20 +50,21 @@ int tst_process_state_wait3(pid_t pid, const char state,
 		if (state == cur_state)
 			return 0;
 
-		usleep(wait_step_ms * 1000);
-		waited_ms += wait_step_ms;
-
-		if (waited_ms >= maxwait_ms) {
-			fprintf(stderr, "Reached max wait time\n");
-			return 1;
-		}
+		nanosleep(&wait_step_ts, NULL);
 	}
+	fprintf(stderr, "Reached max wait time\n");
+	return 1;
 }
 #else
 int tst_process_state_wait3(pid_t pid, const char state,
-	unsigned long maxwait_ms)
+	long maxwait_s)
 {
-	usleep(maxwait_ms * 1000);
+	struct timespec maxwait_ts;
+
+	maxwait_ts.tv_sec = maxwait_s;
+	maxwait_ts.tv_nsec = 0;
+
+	nanosleep(&maxwait_ts, NULL);
 	return 0;
 }
 #endif


### PR DESCRIPTION
usleep(3) has been deprecated as of X/Open Issue 6 and its use on FreeBSD
(at least) results in a compiler warning when _XOPEN_SOURCE > 600. It doesn't
fail to link because FreeBSD's libc exposes the symbol when
_XOPEN_SOURCE <= 600 or _BSD_SOURCE (the equivalent to _GNU_SOURCE for
GNU extensions) is defined (the latter is the case here).

The sleep magnitudes have been adjusted by 1000 since usleep takes
values in microseconds and nanosleep takes values in seconds and
nanoseconds.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>