### PR TITLE
Another two testcase fixes

### DIFF
--- a/testcases/kernel/controllers/memcg/control/memcg_control_test.sh
+++ b/testcases/kernel/controllers/memcg/control/memcg_control_test.sh
@@ -53,6 +53,8 @@ STATUS_PIPE="$TMP/status_pipe"
 PASS=0
 FAIL=1
 
+. test.sh
+
 # Check if the test process is killed on crossing boundary
 test_proc_kill()
 {
@@ -118,7 +120,7 @@ result()
 cleanup()
 {
 	if [ -e $TST_PATH/mnt ]; then
-		umount $TST_PATH/mnt 2> /dev/null
+		tst_umount $TST_PATH/mnt
 		rm -rf $TST_PATH/mnt
 	fi
 }


### PR DESCRIPTION
Commit "controllers/memcg_control: Use tst_umount in cleanup()" is already in an early pull request. Maintainer said that testcase will be removed but it is still here, and the early pull request has closed.

Commit "mem/oom01: Run oom01 test only once" try to avoid oom01 crash the Linux desktop. 