### PR TITLE
Remove unused variables, `argc`/`argv`

### DIFF
--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
@@ -228,7 +228,7 @@ void *thread_tb(void *arg)
 	    return NULL;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
 	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
@@ -264,7 +264,7 @@ void *thread_tb2(void *arg)
 	return NULL;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
 	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
@@ -234,7 +234,7 @@ void *thread_tb2(void *arg)
 	return NULL;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
 	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;


### PR DESCRIPTION
This commit is similar to 3373bb3, both in terms of logic and reasoning
for the change.

Reported by: clang and gcc with -Wunused
Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>