### PR TITLE
Fix compiling open_posix_testsuite on non-Linux platforms

### DIFF
--- a/testcases/open_posix_testsuite/include/affinity.h
+++ b/testcases/open_posix_testsuite/include/affinity.h
@@ -99,6 +99,8 @@ set_affinity:
 }
 
 #else
+#include <errno.h>
+
 static int set_affinity_single(void)
 {
 	errno = ENOSYS;


### PR DESCRIPTION
errno.h is must be included in order to set errno and to obtain the
definition of ENOSYS.

This unbreaks compiling a part of the test suite on OSX and unbreaks it
on FreeBSD.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>