### PR TITLE
Address more unused variables, `argc`/`argv`

### DIFF
--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
@@ -253,7 +253,7 @@ void *thread_tb2(void *arg)
 	return NULL;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
 	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
@@ -252,7 +252,7 @@ void *thread_tb(void *arg)
 	return NULL;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
 	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
@@ -227,7 +227,7 @@ void *thread_tb(void *arg)
 	return NULL;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
 	cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	pthread_mutexattr_t mutex_attr;


### PR DESCRIPTION
Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>