### PR TITLE
Add perror() conformance tests

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/perror/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/perror/1-1.c
@@ -1,0 +1,108 @@
+/*
+ * This file is licensed under the GPL license. For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *	The function will map the error number accessed through the symbol
+ *	errno to a language-dependent error message, which will be written to the standard
+ *	error stream as follows:
+ *		• First (if s is not a null pointer and the character pointed to by s
+ *		is not the null byte), the string pointed to by s followed by a
+ *		'colon' and a 'space'.
+ *		• Then an error message string followed by a 'newline'.
+ *
+ * method:
+ *	-Redirect error from stderr to a file using freopen.
+ *	-Set errno to ERANGE.
+ *	-Call perror() for "strtol" to get error message and it will be
+ *	stored in file.
+ *	-Restore stderr.
+ *	-Use getline to read the error message from the file.
+ *	-split the error line with delimeter space(' ') and check
+ *	whether the error format is as specified in the assertion
+ *	and store error message in perror_str.
+ *	-Remove extra space in the begining and new line at the end of perror_str.
+ *	-Store errno message from stderror with the errno got
+ *	from strtol and store it in stderror_str.
+ *	-compare perror_str and stderor_str.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <limits.h>
+#include "posixtest.h"
+#include <features.h>
+#include <wchar.h>
+
+#define TNAME "perror/1-1.c"
+
+int main(void)
+{
+	FILE *fp;
+	char *read_line = NULL;
+	ssize_t read;
+	size_t len;
+	char *perror_str;
+	char *strerr_str;
+	char *token;
+	int i;
+
+	int temp_strerr = dup(2);
+
+	/* Redirecting stderr to a file */
+	fp = freopen("perror.txt", "w+", stderr);
+	if (fp == NULL) {
+		printf(TNAME " Error at freopen(), errno: %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = ERANGE;
+	perror("strtol");
+	fclose(fp);
+	//Restoring stderr
+	stderr = fdopen(temp_strerr, "w");
+
+	/* Opening file for reading error from file */
+	fp = fopen("perror.txt", "r");
+	read = getline(&read_line, &len, fp);
+	if (read == -1) {
+		printf(TNAME " Error at getline()\n");
+		exit(PTS_UNRESOLVED);
+	}
+	fclose(fp);
+
+	/* Get error string from error line */
+	token = strtok_r(read_line, ":", &perror_str);
+	if (token != NULL && (strcmp(read_line, "strtol") == 0) && (perror_str[0] == ' ')
+					&& (perror_str[strlen(perror_str)-1] == '\n')) {
+		printf(TNAME " Test passed, printed error as, string name followed by ':' and"
+					" space. And a newline at the end.\n");
+	} else {
+		printf(TNAME " Test failed\n, Perror error display format was not as expecetd.\n");
+		exit(PTS_FAIL);
+	}
+
+	/* Removing extra line at the end */
+	perror_str[strlen(perror_str) - 1]  = '\0';
+
+	/* Removing space at the begining */
+	for (i = 0; perror_str[i]; i++)
+		perror_str[i] = perror_str[i+1];
+
+	strerr_str = strerror(errno);
+	if (strcmp(perror_str, strerr_str) == 0) {
+		printf(TNAME " Test Passed, mapped the error number accessed through the symbol"
+					" errno to a language-dependent error message\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test failed, failed to map the error number accessed through the"
+					" symbol errno to a language-dependent error message\n");
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/perror/2-1.sh
+++ b/testcases/open_posix_testsuite/conformance/interfaces/perror/2-1.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#   This file is licensed under the GPL license. For the full content
+#   of this license, see the COPYING file at the top level of this
+#   source tree.
+
+#   assertion:
+#   The contents of the error message strings shall be the same as those
+#	returned by strerror( ) with argument errno.
+
+#   This is tested implicitly via assertion 1.
+
+	echo "Tested implicitly via assertion 1."
+	exit 0

--- a/testcases/open_posix_testsuite/conformance/interfaces/perror/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/perror/3-1.c
@@ -1,0 +1,75 @@
+/*
+ * This file is licensed under the GPL license. For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *	The function will mark for update the last data modification and last file
+ *	status change timestamps of the file associated with the standard error
+ *	stream at some time between its successful completion and exit( ),
+ *	abort( ), or the completion of fflush( ) or fclose( ) on stderr.
+ *
+ * method:
+ *	-Redirect error from stderr to a file using freopen.
+ *	-Note down time stamps for data modification and file status change of the
+ *	file to which we have redirected stderr.
+ *	-Set errno to ERANGE.
+ *	-Call perror().
+ *	-Check time stamps for data modification and file status change of the
+ *	file to which we have redirected stderr and it should be greater than
+ *	previously noted values, that is before call of perror.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <limits.h>
+#include "posixtest.h"
+#include <features.h>
+#include <wchar.h>
+#include <time.h>
+#include <sys/stat.h>
+
+#define TNAME "perror/3-1.c"
+
+int main(void)
+{
+	struct stat buf;
+	time_t data_modification_freopen, data_modification_perror;
+	time_t file_status_freopen, file_status_perror;
+	FILE *fp;
+
+	fp = freopen("perror.txt", "w+", stderr);
+	if (fp == NULL) {
+		printf(TNAME " Error at freopen(), errno: %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	stat("perror.txt", &buf);
+	data_modification_freopen = buf.st_mtime;
+	file_status_freopen = buf.st_ctime;
+	sleep(2);
+
+	errno = ERANGE;
+	perror("strtol");
+	stat("perror.txt", &buf);
+	data_modification_perror = buf.st_mtime;
+	file_status_perror = buf.st_ctime;
+
+	if (data_modification_freopen < data_modification_perror &&
+			file_status_freopen < file_status_perror) {
+		printf(TNAME " Test Passed, last data modification and last file status"
+				" change timestamps of the file associated with stderr stream"
+				" are updated.\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed, failed to update last data modification and"
+				" last file status change timestamps of the file associated"
+				" with stderr stream.\n");
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/perror/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/perror/4-1.c
@@ -1,0 +1,48 @@
+/*
+ * This file is licensed under the GPL license. For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *	The function will not change the orientation of the standard error stream.
+ *
+ * method:
+ *	-Set errno to ERANGE.
+ *	-Set stderr stream orientation to 1 using fwide().
+ *	-Call perror() for "strtol".
+ *	-Check fwide orientation after perror().
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <limits.h>
+#include "posixtest.h"
+#include <features.h>
+#include <wchar.h>
+
+#define TNAME "perror/4-1.c"
+
+int main(void)
+{
+	int ret;
+
+	errno = ERANGE;
+	ret = fwide(stderr, 1);
+	perror("strtol");
+	ret = fwide(stderr, 0);
+
+	if (ret == 1) {
+		printf(TNAME " Test Passed, orientation of the standard error stream"
+					" is unchanged.\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed, orientation of the standard error stream"
+					" is changed.\n");
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/perror/6-1.sh
+++ b/testcases/open_posix_testsuite/conformance/interfaces/perror/6-1.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+#	This file is licensed under the GPL license. For the full content
+#	of this license, see the COPYING file at the top level of this
+#	source tree.
+
+#	assertion:
+#	The function will not return a value.
+
+#	This is tested implicitly via assertion 1.
+
+	echo " Tested implicitly via assertion 1. See output for status"
+	exit 0

--- a/testcases/open_posix_testsuite/conformance/interfaces/perror/assertions.xml
+++ b/testcases/open_posix_testsuite/conformance/interfaces/perror/assertions.xml
@@ -1,0 +1,31 @@
+<assertions>
+  <assertion id="1" tag="ref:XBD7:47404:47409">
+    The function will map the error number accessed through the symbol errno to
+    a language-dependent error message, which will be written to the standard
+    error stream as follows:
+        • First (if s is not a null pointer and the character pointed to by s
+          is not the null byte), the string pointed to by s followed by a
+          'colon' and a 'space'.
+        • Then an error message string followed by a 'newline'.
+  <assertion>
+  <assertion id="2" tag="ref:XBD7:47410:47411">
+    The contents of the error message strings will be the same as those returned
+    by strerror( ) with argument errno.
+  <assertion>
+  <assertion id="3" tag="ref:XBD7:47412:47414">
+    The function will mark for update the last data modification and last file
+    status change timestamps of the file associated with the standard error
+    stream at some time between its successful completion and exit( ),
+    abort( ), or the completion of fflush( ) or fclose( ) on stderr.
+  <assertion>
+  <assertion id="4" tag="ref:XBD7:47415:47415">
+    The function will not change the orientation of the standard error stream.
+  <assertion>
+  <assertion id="5" tag="ref:XBD7:47416:47417">
+    On error, perror( ) will set the error indicator for the stream to which
+    stderr points, and shall set errno to indicate the error.
+  <assertion>
+  <assertion id="6" tag="ref:XBD7:47422:47422">
+    The function will not return a value.
+  <assertion>
+<assertions>

--- a/testcases/open_posix_testsuite/conformance/interfaces/perror/coverage.txt
+++ b/testcases/open_posix_testsuite/conformance/interfaces/perror/coverage.txt
@@ -1,0 +1,12 @@
+This file defines the coverage for the perror() function testing.
+
+	Assertion	Status
+	1			YES
+	2			YES
+	3			YES
+	4			YES
+	5			NO*
+	6			YES
+
+	* Hard to test assertions
+


### PR DESCRIPTION
Adds 1-1, 2-1, 3-1, 4-1 and 6-1 tests, assertions.xml and coverage.txt

Change-Id: Iebfd407ddaf1214c9dda68a1877649e52e021a87
Signed-off-by: Mandri, Padmashree <padmashree.mandri@intel.com>