### PR TITLE
s390x: Fix getrlimit03

### DIFF
--- a/include/lapi/syscalls/regen.sh
+++ b/include/lapi/syscalls/regen.sh
@@ -77,6 +77,7 @@ for arch in $(cat "${srcdir}/order") ; do
 	case ${arch} in
 		sparc64) echo "#if defined(__sparc__) && defined(__arch64__)" ;;
 		sparc) echo "#if defined(__sparc__) && !defined(__arch64__)" ;;
+		s390) echo "#if defined(__s390__) && !defined(__s390x__)" ;;
 		*) echo "#ifdef __${arch}__" ;;
 	esac
 	while read line ; do

--- a/include/lapi/syscalls/s390x.in
+++ b/include/lapi/syscalls/s390x.in
@@ -259,7 +259,7 @@ geteuid 49
 getegid 50
 setreuid 70
 setregid 71
-getrlimit 76
+getrlimit 191
 getgroups 80
 setgroups 81
 fchown 95
@@ -271,7 +271,6 @@ getresuid 165
 setresgid 170
 getresgid 171
 chown 182
-ugetrlimit 191
 mmap2 192
 truncate64 193
 ftruncate64 194


### PR DESCRIPTION
On s390x (64 bit Mainframe) the getrlimit03 test fails as follows:

```
root@~/ltp (master)# ./testcases/kernel/syscalls/getrlimit/getrlimit03 2>&1 | grep FAIL
getrlimit03.c:121: FAIL: __NR_prlimit64(0) had rlim_cur = ffffffffffffffff but __NR_getrlimit(0) had rlim_cur = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(1) had rlim_cur = ffffffffffffffff but __NR_getrlimit(1) had rlim_cur = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(2) had rlim_cur = ffffffffffffffff but __NR_getrlimit(2) had rlim_cur = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(3) had rlim_max = ffffffffffffffff but __NR_getrlimit(3) had rlim_max = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(4) had rlim_cur = ffffffffffffffff but __NR_getrlimit(4) had rlim_cur = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(5) had rlim_cur = ffffffffffffffff but __NR_getrlimit(5) had rlim_cur = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(9) had rlim_cur = ffffffffffffffff but __NR_getrlimit(9) had rlim_cur = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(10) had rlim_cur = ffffffffffffffff but __NR_getrlimit(10) had rlim_cur = ffffffffffffffff
getrlimit03.c:121: FAIL: __NR_prlimit64(15) had rlim_cur = ffffffffffffffff but __NR_getrlimit(15) had rlim_cur = ffffffffffffffff
```

The reason is that the LTP assumes that the s390x architecture has the ugetrlimit() system call which is not true.

To fix the problem the following two commits are required:

 - "lapi/syscalls/s390x: Fix (u)getrlimit syscall numbers"
 - "lapi/regen.sh: Fix s390 check"