### PR TITLE
open_posix_testsuite: Fix -Werror issues (one-offs)

### DIFF
--- a/testcases/open_posix_testsuite/conformance/definitions/aio_h/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/aio_h/4-1.c
@@ -8,18 +8,18 @@
 
 #include <aio.h>
 
-int (*dummy0) (int, struct aiocb *) = aio_cancel;
-int (*dummy1) (const struct aiocb *) = aio_error;
-int (*dummy2) (int, struct aiocb *) = aio_fsync;
-int (*dummy3) (struct aiocb *) = aio_read;
-ssize_t(*dummy4) (struct aiocb *) = aio_return;
-int (*dummy5) (const struct aiocb * const[], int,
+int (*dummy0) (int, struct aiocb*) = aio_cancel;
+int (*dummy1) (const struct aiocb*) = aio_error;
+int (*dummy2) (int, struct aiocb*) = aio_fsync;
+int (*dummy3) (struct aiocb*) = aio_read;
+ssize_t (*dummy4) (struct aiocb*) = aio_return;
+int (*dummy5) (const struct aiocb* const[], int,
 	       const struct timespec *) = aio_suspend;
 int (*dummy6) (struct aiocb *) = aio_write;
-int (*dummy7) (int, struct aiocb * const[],
-	       int, struct sigevent * restrict) = lio_listio;
+int (*dummy7) (int, struct aiocb *restrict const [restrict],
+	       int, struct sigevent *restrict) = lio_listio;
 
-int main()
+int main(void)
 {
 	return 0;
 }

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/14-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/14-1.c
@@ -91,7 +91,7 @@ int main(void)
 	for (i = 0; i < NUM_AIOCBS; i++) {
 
 		aiocbs[i] = (struct aiocb *)calloc(sizeof(struct aiocb), 1);
-		if (aiocbs == NULL) {
+		if (aiocbs[i] == NULL) {
 			printf(TNAME " Error at malloc(): %s\n",
 			       strerror(errno));
 			free(bufs);

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_close/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_close/2-1.c
@@ -35,7 +35,7 @@
 #define PIPE_READ  0
 #define PIPE_WRITE 1
 
-int parent_process(char *qname, int read_pipe, int write_pipe, int child_pid);
+int parent_process(char *qname, int read_pipe, int write_pipe, pid_t child_pid);
 int child_process(char *qname, int read_pipe, int write_pipe);
 mqd_t open_queue(char *qname, int oflag, int mode);
 int send_receive(int read_pipe, int write_pipe, char send, char *reply);
@@ -92,7 +92,8 @@ int main(void)
 	return PTS_UNRESOLVED;
 }
 
-int parent_process(char *qname, int read_pipe, int write_pipe, int child_pid)
+int parent_process(char *qname, int read_pipe, int write_pipe,
+	pid_t child_pid LTP_ATTRIBUTE_UNUSED)
 {
 	mqd_t queue;
 	struct sigevent se;
@@ -238,3 +239,4 @@ int send_receive(int read_pipe, int write_pipe, char send, char *reply)
 
 	return 0;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/9-1.c
@@ -79,7 +79,7 @@ int main(void)
 
 	for (i = 0; i < syslimit; i++) {
 		if (sigqueue(pid, SIGTOTEST, value) != 0) {
-			printf("Failed: sigqueue on %d of %d max, errno: %s\n",
+			printf("Failed: sigqueue on %d of %ld max, errno: %s\n",
 			       i, syslimit, strerror(errno));
 			return PTS_UNRESOLVED;
 		}

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
@@ -35,8 +35,9 @@
  *
  */
 
-#warning "Contains Linux-isms that need fixing."
-
+#ifdef	__linux__
+#define	_GNU_SOURCE
+#endif
 #include <pthread.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -46,6 +47,7 @@
 #include <sched.h>
 #include <errno.h>
 #include "test.h"
+#include "posixtest.h"
 #include "pitest.h"
 
 int cpus;
@@ -99,9 +101,10 @@ void *thread_fn(void *param)
 	struct thread_param *tp = param;
 	struct timespec ts;
 	int rc;
-	unsigned long mask = 1 << tp->cpu;
 
 #if __linux__
+	unsigned long mask = 1 << tp->cpu;
+
 	rc = sched_setaffinity(0, sizeof(mask), &mask);
 	if (rc < 0) {
 		EPRINTF("UNRESOLVED: Thread %s index %d: Can't set affinity: "
@@ -138,10 +141,11 @@ void *thread_fn(void *param)
 void *thread_tl(void *param)
 {
 	struct thread_param *tp = param;
-	unsigned long mask = 1 << tp->cpu;
-	int rc;
 
 #if __linux__
+	int rc;
+	unsigned long mask = 1 << tp->cpu;
+
 	rc = sched_setaffinity((pid_t) 0, sizeof(mask), &mask);
 	if (rc < 0) {
 		EPRINTF
@@ -170,7 +174,7 @@ void *thread_tl(void *param)
 	return NULL;
 }
 
-void *thread_sample(void *arg)
+void *thread_sample(void *arg LTP_ATTRIBUTE_UNUSED)
 {
 	char buffer[1024];
 	struct timespec ts;
@@ -367,3 +371,4 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread\n");
 	return 0;
 }
+

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
@@ -36,8 +36,9 @@
  *
  */
 
-#warning "Contains Linux-isms that need fixing."
-
+#ifdef	__linux__
+#define	_GNU_SOURCE
+#endif
 #include <errno.h>
 #include <pthread.h>
 #include <sched.h>
@@ -46,6 +47,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include "posixtest.h"
 #include "test.h"
 #include "pitest.h"
 
@@ -99,9 +101,10 @@ void *thread_fn(void *param)
 	struct thread_param *tp = param;
 	struct timespec ts;
 	int rc;
-	unsigned long mask = 1 << tp->cpu;
 
 #if __linux__
+	unsigned long mask = 1 << tp->cpu;
+
 	rc = sched_setaffinity(0, sizeof(mask), &mask);
 	if (rc < 0) {
 		EPRINTF("UNRESOLVED: Thread %s index %d: Can't set affinity: "
@@ -139,7 +142,7 @@ void *thread_fn(void *param)
 	return NULL;
 }
 
-void *thread_sample(void *arg)
+void *thread_sample(void *arg LTP_ATTRIBUTE_UNUSED)
 {
 	char buffer[1024];
 	struct timespec ts;
@@ -332,3 +335,4 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread\n");
 	return 0;
 }
+

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
@@ -33,8 +33,9 @@
  * NOTE: Most of the code is ported from test-11 written by inkay.
  */
 
-#warning "Contains Linux-isms that need fixing."
-
+#ifdef	__linux__
+#define	_GNU_SOURCE
+#endif
 #include <errno.h>
 #include <pthread.h>
 #include <sched.h>
@@ -44,6 +45,7 @@
 #include <time.h>
 #include <unistd.h>
 #include "test.h"
+#include "posixtest.h"
 #include "pitest.h"
 
 int cpus;
@@ -95,9 +97,10 @@ void *thread_fn(void *param)
 	struct thread_param *tp = param;
 	struct timespec ts;
 	int rc;
-	unsigned long mask = 1 << tp->cpu;
 
 #if __linux__
+	unsigned long mask = 1 << tp->cpu;
+
 	rc = sched_setaffinity(0, sizeof(mask), &mask);
 	if (rc < 0) {
 		EPRINTF("UNRESOLVED: Thread %s index %d: Can't set affinity: "
@@ -133,10 +136,11 @@ void *thread_fn(void *param)
 void *thread_tl(void *param)
 {
 	struct thread_param *tp = param;
+
+#if __linux__
 	unsigned long mask = 1 << tp->cpu;
 	int rc;
 
-#if __linux__
 	rc = sched_setaffinity((pid_t) 0, sizeof(mask), &mask);
 	if (rc < 0) {
 		EPRINTF
@@ -162,7 +166,7 @@ void *thread_tl(void *param)
 	return NULL;
 }
 
-void *thread_sample(void *arg)
+void *thread_sample(void *arg LTP_ATTRIBUTE_UNUSED)
 {
 	char buffer[1024];
 	struct timespec ts;
@@ -322,3 +326,4 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread\n");
 	return 0;
 }
+


### PR DESCRIPTION
This PR does 2 things:
* Fixes a handful of one-off warnings that would prevent the compiler from building tests if `-Werror` was set in the CFLAGS file.
* Fixes some logic issues found by inspecting warning diagnostic output from the compiler.

Found with: clang
Tested with: CentOS 7.6.1810 (gcc 4.8.5); FreeBSD 13.0-CURRENT (clang 7.0.1)