### PR TITLE
open_posix_testsuite: fix more warnings issues

### DIFF
--- a/testcases/open_posix_testsuite/conformance/definitions/aio_h/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/aio_h/2-1.c
@@ -10,11 +10,14 @@
 
 #include <aio.h>
 #include <stdlib.h>		/* For NULL on non-linux platforms. */
+#include <string.h>
 
 int main(void)
 {
 	struct aiocb aiocb;
 	struct sigevent sigevent;
+
+	memset(&sigevent, 0, sizeof(sigevent));
 
 	aiocb.aio_fildes = -1;
 	aiocb.aio_offset = -1;

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/10-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/10-1-buildonly.c
@@ -17,11 +17,11 @@ void test_mq_timedsend_prototype(void)
 	size_t msg_len;
 	unsigned msg_prio;
 
-	mqdes = NULL;
+	mqdes = 0;
 	msgp = NULL;
 	msg_len = 0;
 	msg_prio = 0;
 
 	err = mq_timedsend(mqdes, msgp, msg_len, msg_prio, &timeout);
-
+	(void)err;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/11-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/11-1-buildonly.c
@@ -9,9 +9,9 @@ line 9696 of the Base Definitions document
 
 void test_mqueue_unlink_prototype()
 {
-	const char *name;
+	const char *name = "bogus";
 	int err;
 
 	err = mq_unlink(name);
-
+	(void)err;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/2-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/2-1-buildonly.c
@@ -15,5 +15,5 @@ void test_mq_close_prototype(void)
 	mqdes = 0;
 
 	err = mq_close(mqdes);
-
+	(void)err;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/2-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/2-1-buildonly.c
@@ -12,6 +12,8 @@ void test_mq_close_prototype(void)
 	mqd_t mqdes;
 	int err;
 
+	mqdes = 0;
+
 	err = mq_close(mqdes);
 
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/3-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/3-1-buildonly.c
@@ -13,5 +13,7 @@ void test_mq_getattr_prototype(void)
 	struct mq_attr mqs;
 	int err;
 
+	mqdes = 0;
+
 	err = mq_getattr(mqdes, &mqs);
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/3-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/3-1-buildonly.c
@@ -16,4 +16,5 @@ void test_mq_getattr_prototype(void)
 	mqdes = 0;
 
 	err = mq_getattr(mqdes, &mqs);
+	(void)err;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/4-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/4-1-buildonly.c
@@ -19,5 +19,5 @@ void test_mq_notify_prototype(void)
 	notification = NULL;
 
 	err = mq_notify(mqdes, notification);
-
+	(void)err;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/4-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/4-1-buildonly.c
@@ -5,6 +5,8 @@
 */
 
 #include <mqueue.h>
+#include <stdlib.h>
+
 #include "posixtest.h"
 
 void test_mq_notify_prototype(void)
@@ -12,6 +14,9 @@ void test_mq_notify_prototype(void)
 	mqd_t mqdes;
 	struct sigevent *notification;
 	int err;
+
+	mqdes = 0;
+	notification = NULL;
 
 	err = mq_notify(mqdes, notification);
 

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/5-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/5-1-buildonly.c
@@ -4,15 +4,15 @@
   line 9687 of the Base Definitions document
 */
 
+#include <fcntl.h>
 #include <mqueue.h>
 #include "posixtest.h"
 
 void test_mq_open_prototype(void)
 {
 	mqd_t res;
-	int oflag;
+	int oflag = O_RDONLY;
 	const char *name;
 
 	res = mq_open(name, oflag);
-
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/5-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/5-1-buildonly.c
@@ -12,7 +12,8 @@ void test_mq_open_prototype(void)
 {
 	mqd_t res;
 	int oflag = O_RDONLY;
-	const char *name;
+	const char *name = "bogus";
 
 	res = mq_open(name, oflag);
+	(void)res;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/6-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/6-1-buildonly.c
@@ -5,6 +5,7 @@
 */
 
 #include <mqueue.h>
+#include <stdlib.h>
 #include "posixtest.h"
 
 void test_mq_receive_prototype(void)
@@ -14,6 +15,10 @@ void test_mq_receive_prototype(void)
 	size_t msg_len;
 	char *msgp;
 	unsigned msg_prio;
+
+	mqdes = 0;
+	msg_len = 0;
+	msgp = NULL;
 
 	msg_size = mq_receive(mqdes, msgp, msg_len, &msg_prio);
 

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/6-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/6-1-buildonly.c
@@ -21,5 +21,5 @@ void test_mq_receive_prototype(void)
 	msgp = NULL;
 
 	msg_size = mq_receive(mqdes, msgp, msg_len, &msg_prio);
-
+	(void)msg_size;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/7-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/7-1-buildonly.c
@@ -5,6 +5,7 @@
 */
 
 #include <mqueue.h>
+#include <stdlib.h>
 #include "posixtest.h"
 
 void test_mq_send_prototype(void)
@@ -14,6 +15,10 @@ void test_mq_send_prototype(void)
 	char *msgp;
 	int err;
 	unsigned msg_prio;
+
+	mqdes = 0;
+	msg_len = 0;
+	msgp = NULL;
 
 	err = mq_receive(mqdes, msgp, msg_len, &msg_prio);
 

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/7-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/7-1-buildonly.c
@@ -21,5 +21,5 @@ void test_mq_send_prototype(void)
 	msgp = NULL;
 
 	err = mq_receive(mqdes, msgp, msg_len, &msg_prio);
-
+	(void)err;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/8-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/8-1-buildonly.c
@@ -17,5 +17,5 @@ void test_mq_setattr_prototype(void)
 	mqdes = 0;
 
 	err = mq_setattr(mqdes, &mqs, &omqs);
-
+	(void)err;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/8-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/8-1-buildonly.c
@@ -14,6 +14,8 @@ void test_mq_setattr_prototype(void)
 	struct mq_attr mqs, omqs;
 	int err;
 
+	mqdes = 0;
+
 	err = mq_setattr(mqdes, &mqs, &omqs);
 
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/9-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/9-1-buildonly.c
@@ -22,5 +22,5 @@ void test_mq_timedreceive_prototype(void)
 	msgp = NULL;
 
 	size = mq_timedreceive(mqdes, msgp, msg_len, &msg_prio, &abstime);
-
+	(void)size;
 }

--- a/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/9-1-buildonly.c
+++ b/testcases/open_posix_testsuite/conformance/definitions/mqueue_h/9-1-buildonly.c
@@ -17,6 +17,10 @@ void test_mq_timedreceive_prototype(void)
 	char *msgp;
 	unsigned msg_prio;
 
+	mqdes = 0;
+	msg_len = 0;
+	msgp = NULL;
+
 	size = mq_timedreceive(mqdes, msgp, msg_len, &msg_prio, &abstime);
 
 }

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/1-1.c
@@ -220,5 +220,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_suspend/1-1.c
@@ -50,10 +50,10 @@
 #define BUF_SIZE	(1024*1024)
 #define WAIT_FOR_AIOCB	6
 
-static int received_selected;
-static int received_all;
+static volatile int received_all;
 
-static void sigrt1_handler(int signum, siginfo_t *info, void *context)
+static void sigrt1_handler(int signum LTP_ATTRIBUTE_UNUSED,
+	siginfo_t *info LTP_ATTRIBUTE_UNUSED, void *context LTP_ATTRIBUTE_UNUSED)
 {
 	received_all = 1;
 }
@@ -220,3 +220,5 @@ int main(void)
 
 	return PTS_PASS;
 }
+
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_write/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_write/7-1.c
@@ -92,7 +92,12 @@ int main(void)
 
 	printf("Failed at %d\n", last_req);
 
-	if ((ret != -1) && (errno != EAGAIN)) {
+	/*
+	 * XXX (ngie): this check seems incorrect, given the
+	 *             requirements/description for the API and test,
+	 *             respectively.
+	 */
+	if (ret != -1 && errno != EAGAIN) {
 		printf(TNAME " failed with code %d: %s\n", errno,
 		       strerror(errno));
 		close(fd);

--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_settime/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/clock_settime/5-1.c
@@ -117,7 +117,7 @@ int main(void)
 		return PTS_FAIL;
 	}
 
-	if (abs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
+	if (labs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
 		printf("Test PASSED\n");
 		tsreset.tv_sec += TIMERSEC;
 		setBackTime(tsreset);

--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_settime/5-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/clock_settime/5-2.c
@@ -117,7 +117,7 @@ int main(void)
 		return PTS_FAIL;
 	}
 
-	if (abs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
+	if (labs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
 		printf("Test PASSED\n");
 		tsreset.tv_sec += TIMERSEC;
 		setBackTime(tsreset);

--- a/testcases/open_posix_testsuite/conformance/interfaces/fork/19-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fork/19-1.c
@@ -67,7 +67,7 @@ int main(void)
 	mq = mq_open(queue_name, O_RDWR | O_CREAT | O_NONBLOCK,
 		     S_IRUSR | S_IWUSR, &mqa);
 
-	if (mq == -1) {
+	if (mq == (mqd_t)-1) {
 		perror("Failed to create the message queue descriptor");
 		return PTS_UNRESOLVED;
 	}

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/1-1.c
@@ -161,4 +161,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/10-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/10-1.c
@@ -166,4 +166,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/14-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/14-1.c
@@ -191,4 +191,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/15-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/15-1.c
@@ -184,4 +184,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/2-1.c
@@ -185,4 +185,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/3-1.c
@@ -166,4 +166,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/4-1.c
@@ -195,4 +195,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/lio_listio/7-1.c
@@ -190,4 +190,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/mmap/11-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mmap/11-4.c
@@ -39,7 +39,9 @@
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
+#ifdef	__linux__
 #include <sys/vfs.h>
+#endif
 #include "posixtest.h"
 
 #define TYPE_TMPFS_MAGIC	0x01021994
@@ -56,12 +58,13 @@ int main(void)
 	pid_t child;
 	int i, exit_val;
 
-	struct statfs buf;
-
 	page_size = sysconf(_SC_PAGE_SIZE);
 
 	/* mmap will create a partial page */
 	len = page_size / 2;
+
+#ifdef	__linux__
+	struct statfs buf;
 
 	if (statfs("/tmp", &buf)) {
 		printf("Error at statfs(): %s\n", strerror(errno));
@@ -72,6 +75,7 @@ int main(void)
 		printf("From mmap(2) manpage, skip known bug on tmpfs\n");
 		return PTS_UNTESTED;
 	}
+#endif
 
 	snprintf(tmpfname, sizeof(tmpfname), "/tmp/pts_mmap_11_5_%d", getpid());
 	child = fork();

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_close/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_close/2-1.c
@@ -239,4 +239,3 @@ int send_receive(int read_pipe, int write_pipe, char send, char *reply)
 
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_receive/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_receive/1-1.c
@@ -69,8 +69,8 @@ int main(void)
 		    ("FAIL: mq_receive didn't receive the highest priority message\n");
 		failure = 1;
 	}
-	if (rvprio != sdprio2) {
-		printf("FAIL: receive priority %d != send priority %d \n",
+	if ((int)rvprio != sdprio2) {
+		printf("FAIL: receive priority %u != send priority %d\n",
 		       rvprio, sdprio2);
 		failure = 1;
 	}
@@ -82,8 +82,8 @@ int main(void)
 		printf("FAIL: mq_receive didn't receive the correct message\n");
 		failure = 1;
 	}
-	if (rvprio != sdprio1) {
-		printf("FAIL: receive priority %d != send priority %d \n",
+	if ((int)rvprio != sdprio1) {
+		printf("FAIL: receive priority %u != send priority %d\n",
 		       rvprio, sdprio1);
 		failure = 1;
 	}

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_receive/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_receive/8-1.c
@@ -40,15 +40,16 @@ int main(void)
 	const char *msgptr2 = "test message2 with differnet length";
 	mqd_t mqdes;
 	int prio1 = 1, prio2 = 2;
-	struct mq_attr attr;
+	struct mq_attr attr = {
+		.mq_msgsize = BUFFER,
+		.mq_maxmsg = BUFFER
+	};
 	int unresolved = 0, failure = 0;
 
 	sprintf(mqname, "/" FUNCTION "_" TEST "_%d", getpid());
 
-	attr.mq_msgsize = BUFFER;
-	attr.mq_maxmsg = BUFFER;
 	mqdes = mq_open(mqname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, &attr);
-	if (mqdes == (mqd_t) - 1) {
+	if (mqdes == (mqd_t)-1) {
 		perror(ERROR_PREFIX "mq_open");
 		unresolved = 1;
 	}
@@ -62,14 +63,16 @@ int main(void)
 		unresolved = 1;
 	}
 
-	if (mq_receive(mqdes, msgrv1, BUFFER, NULL) != strlen(msgptr2)) {
-		printf
-		    ("FAIL: mq_receive didn't return the selected message size correctly \n");
+	if (mq_receive(mqdes, msgrv1, BUFFER, NULL) !=
+	    (ssize_t)strlen(msgptr2)) {
+		printf("FAIL: mq_receive didn't return the selected message "
+		    "size correctly\n");
 		failure = 1;
 	}
-	if (mq_receive(mqdes, msgrv2, BUFFER, NULL) != strlen(msgptr1)) {
-		printf
-		    ("FAIL: mq_receive didn't return the selected message size correctly \n");
+	if (mq_receive(mqdes, msgrv2, BUFFER, NULL) !=
+	    (ssize_t)strlen(msgptr1)) {
+		printf("FAIL: mq_receive didn't return the selected message "
+		    "size correctly\n");
 		failure = 1;
 	}
 	if (!strcmp(msgrv1, msgrv2)) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_timedreceive/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_timedreceive/11-1.c
@@ -50,7 +50,7 @@ int main(void)
 	attr.mq_msgsize = BUFFER;
 	attr.mq_maxmsg = BUFFER;
 	mqdes = mq_open(mqname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, &attr);
-	if (mqdes == (mqd_t) - 1) {
+	if (mqdes == (mqd_t)-1) {
 		perror(ERROR_PREFIX "mq_open");
 		unresolved = 1;
 	}
@@ -66,13 +66,13 @@ int main(void)
 	ts.tv_sec = time(NULL) + 1;
 	ts.tv_nsec = 0;
 	if (mq_timedreceive(mqdes, msgrv1, BUFFER, NULL, &ts) !=
-	    strlen(msgptr2)) {
+	    (ssize_t)strlen(msgptr2)) {
 		printf("FAIL: mq_timedreceive didn't return the selected "
 		       "message size correctly\n");
 		failure = 1;
 	}
 	if (mq_timedreceive(mqdes, msgrv2, BUFFER, NULL, &ts) !=
-	    strlen(msgptr1)) {
+	    (ssize_t)strlen(msgptr1)) {
 		printf("FAIL: mq_timedreceive didn't return the selected "
 		       "message size correctly\n");
 		failure = 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/12-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/12-1.c
@@ -46,7 +46,7 @@
 	do { errno = en; perror(msg); exit(PTS_UNRESOLVED); } while (0)
 
 /* variable to indicate how many times signal handler was called */
-static volatile sig_atomic_t in_handler;
+static volatile int in_handler;
 
 /* errno returned by mq_timedsend() */
 static int mq_timedsend_errno = -1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/1-1.c
@@ -36,12 +36,12 @@ int main(void)
 	sprintf(mqname, "/" FUNCTION "_" TEST "_%d", getpid());
 
 	mqdes = mq_open(mqname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, 0);
-	if (mqdes == (mqd_t) - 1) {
+	if (mqdes == (mqd_t)-1) {
 		perror(ERROR_PREFIX "mq_open");
 		return PTS_UNRESOLVED;
 	}
 	if (mq_unlink(mqname) == 0) {
-		if (mq_open(mqname, O_RDWR, S_IRUSR | S_IWUSR, 0) == -1) {
+		if (mq_open(mqname, O_RDWR, S_IRUSR | S_IWUSR, 0) == (mqd_t)-1) {
 			printf("Test PASSED\n");
 			return PTS_PASS;
 		} else {

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-1.c
@@ -183,4 +183,3 @@ int send_receive(int read_pipe, int write_pipe, char send, char *reply)
 	}
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-1.c
@@ -44,7 +44,7 @@
 
 #define NAMESIZE	50
 
-int parent_process(char *mqname, int read_pipe, int write_pipe, int child_pid);
+int parent_process(char *mqname, int read_pipe, int write_pipe, pid_t child_pid);
 int child_process(char *mqname, int read_pipe, int write_pipe);
 int send_receive(int read_pipe, int write_pipe, char send, char *reply);
 
@@ -93,14 +93,15 @@ int main(void)
 	}
 }
 
-int parent_process(char *mqname, int read_pipe, int write_pipe, int child_pid)
+int parent_process(char *mqname, int read_pipe, int write_pipe,
+	pid_t child_pid LTP_ATTRIBUTE_UNUSED)
 {
 	mqd_t mqdes;
 	char reply;
 	int rval;
 
 	mqdes = mq_open(mqname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, 0);
-	if (mqdes == (mqd_t) - 1) {
+	if (mqdes == (mqd_t)-1) {
 		perror(ERROR_PREFIX "mq_open");
 		return PTS_UNRESOLVED;
 	}
@@ -115,7 +116,7 @@ int parent_process(char *mqname, int read_pipe, int write_pipe, int child_pid)
 	}
 	if (mq_unlink(mqname) == 0) {
 		if (mq_open(mqname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, 0) ==
-		    -1) {
+		    (mqd_t)-1) {
 			printf
 			    ("mq_open to recreate the message	mqueue may fail until all references to the message queue have been closed, or until the message queue is actually removed. \n");
 			printf("Test PASSED\n");
@@ -150,7 +151,7 @@ int child_process(char *mqname, int read_pipe, int write_pipe)
 		return PTS_UNRESOLVED;
 	}
 	mqdes = mq_open(mqname, O_RDWR, 0, 0);
-	if (mqdes == (mqd_t) - 1) {
+	if (mqdes == (mqd_t)-1) {
 		perror(ERROR_PREFIX "mq_open");
 		return PTS_UNRESOLVED;
 	}
@@ -182,3 +183,4 @@ int send_receive(int read_pipe, int write_pipe, char send, char *reply)
 	}
 	return 0;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-2.c
@@ -198,4 +198,3 @@ int send_receive(int read_pipe, int write_pipe, char send, char *reply)
 	}
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_unlink/2-2.c
@@ -39,7 +39,7 @@
 #define FUNCTION "mq_unlink"
 #define ERROR_PREFIX "unexpected error: " FUNCTION " " TEST ": "
 
-int parent_process(char *mqname, int read_pipe, int write_pipe, int child_pid);
+int parent_process(char *mqname, int read_pipe, int write_pipe, pid_t child_pid);
 int child_process(char *mqname, int read_pipe, int write_pipe);
 int send_receive(int read_pipe, int write_pipe, char send, char *reply);
 
@@ -88,14 +88,15 @@ int main(void)
 	}
 }
 
-int parent_process(char *mqname, int read_pipe, int write_pipe, int child_pid)
+int parent_process(char *mqname, int read_pipe, int write_pipe,
+	pid_t child_pid LTP_ATTRIBUTE_UNUSED)
 {
 	mqd_t mqdes;
 	char reply;
 	int rval;
 
 	mqdes = mq_open(mqname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, 0);
-	if (mqdes == (mqd_t) - 1) {
+	if (mqdes == (mqd_t)-1) {
 		perror(ERROR_PREFIX "mq_open");
 		return PTS_UNRESOLVED;
 	}
@@ -119,7 +120,7 @@ int parent_process(char *mqname, int read_pipe, int write_pipe, int child_pid)
 			return PTS_UNRESOLVED;
 		}
 		if (mq_open(mqname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, 0) !=
-		    -1) {
+		    (mqd_t)-1) {
 			if (mq_unlink(mqname) != 0) {
 				perror(ERROR_PREFIX "mq_unlink(2)");
 				return PTS_UNRESOLVED;
@@ -152,7 +153,7 @@ int child_process(char *mqname, int read_pipe, int write_pipe)
 		return PTS_UNRESOLVED;
 	}
 	mqdes = mq_open(mqname, O_RDWR, 0, 0);
-	if (mqdes == (mqd_t) - 1) {
+	if (mqdes == (mqd_t)-1) {
 		perror(ERROR_PREFIX "mq_open");
 		return PTS_UNRESOLVED;
 	}
@@ -197,3 +198,4 @@ int send_receive(int read_pipe, int write_pipe, char send, char *reply)
 	}
 	return 0;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/1-2.c
@@ -42,7 +42,9 @@
 #include <sys/mman.h>
 #include <sys/wait.h>
 #include <semaphore.h>
+#ifdef	__linux__
 #include <sys/sysinfo.h>
+#endif
 
 #include "../testfrmw/testfrmw.h"
 #include "../testfrmw/testfrmw.c"
@@ -165,7 +167,7 @@ struct testdata {
 struct testdata *td;
 
 /* Child function (either in a thread or in a process) */
-static void *child(void *arg)
+static void *child(void *arg LTP_ATTRIBUTE_UNUSED)
 {
 	int ret = 0;
 	struct timespec ts;
@@ -235,7 +237,7 @@ children_t *children = &sentinel;
 
 sem_t sem_tmr;
 
-void *timer(void *arg)
+void *timer(void *arg LTP_ATTRIBUTE_UNUSED)
 {
 	unsigned int to = TIMEOUT;
 	int ret;
@@ -420,7 +422,7 @@ int main(void)
 		UNRESOLVED(ret, "Failed to initialize the semaphore");
 
 	/* Do the test for each test scenario */
-	for (scenar = 0; scenar < NSCENAR; scenar++) {
+	for (scenar = 0; scenar < (int)NSCENAR; scenar++) {
 		/* set / reset everything */
 		td->fork = 0;
 		ret = pthread_mutexattr_init(&ma);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/2-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/2-3.c
@@ -349,7 +349,7 @@ int main(void)
 		UNRESOLVED(ret, "[parent] Failed to set thread stack size");
 
 	/* Do the test for each test scenario */
-	for (scenar = 0; scenar < NSCENAR; scenar++) {
+	for (scenar = 0; scenar < (int)NSCENAR; scenar++) {
 		/* set / reset everything */
 		td->fork = 0;
 		ret = pthread_mutexattr_init(&ma);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_destroy/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_destroy/2-1.c
@@ -437,7 +437,7 @@ int main(void)
 	}
 
 	/* Do the test for each test scenario */
-	for (scenar = 0; scenar < NSCENAR; scenar++) {
+	for (scenar = 0; scenar < (int)NSCENAR; scenar++) {
 		/* set / reset everything */
 		td->fork = 0;
 		ret = pthread_mutexattr_init(&ma);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/1-2.c
@@ -395,7 +395,7 @@ int main(void)
 	}
 
 	/* Do the test for each test scenario */
-	for (scenar = 0; scenar < NSCENAR; scenar++) {
+	for (scenar = 0; scenar < (int)NSCENAR; scenar++) {
 		/* set / reset everything */
 		td->fork = 0;
 		ret = pthread_mutexattr_init(&ma);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-2.c
@@ -176,6 +176,8 @@ struct _scenar {
 #endif
 };
 
+#define NSCENAR (sizeof(scenarii) / sizeof(scenarii[0]))
+
 void *tf(void *arg)
 {
 	int ret = 0;
@@ -361,7 +363,7 @@ int main(void)
 /**********
  * For each test scenario, initialize the attributes and other variables.
  */
-	for (i = 0; i < (sizeof(scenarii) / sizeof(scenarii[0])); i++) {
+	for (i = 0; i < (int)NSCENAR; i++) {
 #if VERBOSE > 1
 		output("[parent] Preparing attributes for: %s\n",
 		       scenarii[i].descr);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_wait/2-3.c
@@ -251,6 +251,8 @@ int main(void)
 #endif
 	};
 
+#define NSCENAR (sizeof(scenar) / sizeof(scenar[0]))
+
 	output_init();
 
 	/* Initialize the constants */
@@ -284,7 +286,7 @@ int main(void)
 	}
 
 	struct timespec wait_ts = {0, 100000};
-	for (i = 0; i < (sizeof(scenar) / sizeof(scenar[0])); i++) {
+	for (i = 0; i < (int)NSCENAR; i++) {
 #if VERBOSE > 1
 		output("Starting test for %s\n", scenar[i].descr);
 #endif

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_getschedparam/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_getschedparam/1-2.c
@@ -27,7 +27,7 @@
 #define ERR_MSG(f, rc)  printf("Failed: func %s rc: %s (%u)\n", \
 				f, strerror(rc), rc)
 
-void *thread_func(void)
+void *thread_func(void* arg LTP_ATTRIBUTE_UNUSED)
 {
 	struct sched_param sparam;
 	int policy, priority, policy_1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/1-1.c
@@ -45,8 +45,8 @@
 #define INMAIN 1
 #define SIGTOTEST SIGABRT
 
-int sem1;			/* Manual semaphore */
-int handler_called = 0;
+static int sem1;			/* Manual semaphore */
+static volatile int handler_called;
 
 void handler()
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/1-2.c
@@ -166,4 +166,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_destroy/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_destroy/2-2.c
@@ -99,7 +99,7 @@ struct _scenar {
 int main(void)
 {
 	int ret;
-	int i, j;
+	unsigned int i, j;
 	pthread_mutex_t mtx;
 	pthread_mutexattr_t ma[NSCENAR + 1];
 	pthread_mutexattr_t *pma[NSCENAR + 2];

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_destroy/5-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_destroy/5-2.c
@@ -100,7 +100,7 @@ struct _scenar {
 int main(void)
 {
 	int ret;
-	int i;
+	unsigned int i;
 	pthread_mutex_t mtx;
 	pthread_mutexattr_t ma[NSCENAR + 1];
 	pthread_mutexattr_t *pma[NSCENAR + 2];

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_trylock/4-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_trylock/4-2.c
@@ -256,7 +256,7 @@ int main(void)
  * For each test scenario, initialize the attributes and other variables.
  * Do the whole thing for each time to test.
  */
-	for (sc = 0; sc < NSCENAR; sc++) {
+	for (sc = 0; sc < (int)NSCENAR; sc++) {
 #if VERBOSE > 1
 		output("[parent] Preparing attributes for: %s\n",
 		       scenarii[sc].descr);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_trylock/4-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_mutex_trylock/4-3.c
@@ -194,7 +194,7 @@ void *test(void *arg LTP_ATTRIBUTE_UNUSED)
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);
 
 	/* Initialize the mutex objects according to the scenarii */
-	for (i = 0; i < NSCENAR; i++) {
+	for (i = 0; i < (int)NSCENAR; i++) {
 		ret = pthread_mutexattr_init(&ma[i]);
 		if (ret != 0) {
 			UNRESOLVED(ret,
@@ -277,7 +277,7 @@ void *test(void *arg LTP_ATTRIBUTE_UNUSED)
 	}
 
 	/* Destroy everything */
-	for (i = 0; i <= NSCENAR; i++) {
+	for (i = 0; i <= (int)NSCENAR; i++) {
 		ret = pthread_mutex_destroy(&mtx[i]);
 		if (ret != 0) {
 			UNRESOLVED(ret, "Failed to destroy the mutex");

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/12-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/12-1.c
@@ -49,7 +49,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/4-1.c
@@ -133,4 +133,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/5-1.c
@@ -145,4 +145,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/6-1.c
@@ -154,4 +154,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/7-1.c
@@ -41,7 +41,7 @@ void *a_thread_func()
 		SIGTRAP, SIGURG, SIGVTALRM, SIGXCPU, SIGXFSZ
 	};
 
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		sigemptyset(&oactl);
 		sigemptyset(&tempset);
 		sigaddset(&tempset, siglist[i]);

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/8-1.c
@@ -43,7 +43,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/8-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/8-2.c
@@ -45,7 +45,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/8-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/8-3.c
@@ -43,7 +43,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/9-1.c
@@ -120,4 +120,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/9-1.c
@@ -38,7 +38,7 @@ int main(void)
 {
 	sem_t mysemp;
 	struct timespec ts;
-	int pid, status;
+	pid_t pid;
 
 	if (sem_init(&mysemp, 0, 1) == -1) {
 		perror(ERROR_PREFIX "sem_init");
@@ -80,7 +80,7 @@ int main(void)
 	} else {		// parent to send a signal to child
 		int i;
 		sleep(1);
-		status = kill(pid, SIGABRT);	// send signal to child
+		(void)kill(pid, SIGABRT);	// send signal to child
 		if (wait(&i) == -1) {
 			perror("Error waiting for child to exit\n");
 			return PTS_UNRESOLVED;

--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_wait/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_wait/7-1.c
@@ -36,7 +36,7 @@ int main(void)
 {
 	sem_t *mysemp;
 	char semname[28];
-	int pid, status;
+	pid_t pid;
 
 	sprintf(semname, "/" FUNCTION "_" TEST "_%d", getpid());
 
@@ -78,7 +78,7 @@ int main(void)
 	} else {		// parent to send a signal to child
 		int i;
 		sleep(1);
-		status = kill(pid, SIGABRT);	// send signal to child
+		(void)kill(pid, SIGABRT);	// send signal to child
 		if (wait(&i) == -1) {
 			perror("Error waiting for child to exit\n");
 			return PTS_UNRESOLVED;

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-1.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-10.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-11.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-12.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-13.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-14.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-15.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-16.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-17.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-18.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-19.c
@@ -58,4 +58,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-2.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-20.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-21.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-22.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-23.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-24.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-25.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-26.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-3.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-4.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-5.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-6.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-7.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-8.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/1-9.c
@@ -57,4 +57,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/10-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/10-1.c
@@ -115,4 +115,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return -1;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/11-1.c
@@ -123,4 +123,3 @@ int main(void)
 	     "continued. Again, this is not a bug because of the existence of the word *MAY* in the spec.\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-1.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-10.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-11.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-12.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-13.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-14.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-15.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-16.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-17.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-18.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-19.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-2.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-20.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-21.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-22.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-23.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-24.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-25.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-26.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-3.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-4.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-5.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-6.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-7.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-8.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/13-9.c
@@ -69,4 +69,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-1.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-10.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-11.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-12.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-13.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-14.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-15.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-16.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-17.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-18.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-19.c
@@ -89,4 +89,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-2.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-20.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-21.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-22.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-23.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-24.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-25.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-26.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-3.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-4.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-5.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-6.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-7.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-8.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/17-9.c
@@ -90,4 +90,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-1.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-10.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-11.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-12.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-13.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-14.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-15.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-16.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-17.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-18.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-19.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-2.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-20.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-21.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-22.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-23.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-24.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-25.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-26.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-3.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-4.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-5.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-6.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-7.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-8.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/2-9.c
@@ -59,4 +59,3 @@ int main(void)
 	printf("Test Failed\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/21-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/21-1.c
@@ -49,4 +49,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-1.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-10.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-11.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-12.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-13.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-14.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-15.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-16.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-17.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-18.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-19.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-2.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-20.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-21.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-22.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-23.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-24.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-25.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-26.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-3.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-4.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-5.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-6.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-7.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-8.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/22-9.c
@@ -100,4 +100,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-1.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-10.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-11.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-12.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-13.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-14.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-15.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-16.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-17.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-18.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-19.c
@@ -154,4 +154,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-2.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-20.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-21.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-22.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-23.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-24.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-25.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-26.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-3.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-4.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-5.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-6.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-7.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-8.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-9.c
@@ -162,4 +162,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-1.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-10.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-11.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-12.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-13.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-14.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-15.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-16.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-17.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-18.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-19.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-2.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-20.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-21.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-22.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-23.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-24.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-25.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-26.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-3.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-4.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-5.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-6.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-7.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-8.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/25-9.c
@@ -102,4 +102,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/29-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/29-1.c
@@ -203,4 +203,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-1.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-10.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-11.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-12.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-13.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-14.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-15.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-16.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-17.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-18.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-19.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-2.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-20.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-21.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-22.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-23.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-24.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-25.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-26.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-3.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-4.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-5.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-6.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-7.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-8.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/3-9.c
@@ -63,4 +63,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/30-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/30-1.c
@@ -204,4 +204,3 @@ int main(void)
 
 	PASSED;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-1.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-10.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-100.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-100.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-101.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-101.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-102.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-102.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-103.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-103.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-104.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-104.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-11.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-12.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-13.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-14.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-15.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-16.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-17.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-18.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-19.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-2.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-20.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-21.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-22.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-23.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-24.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-25.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-26.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-27.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-27.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-28.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-28.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-29.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-29.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-3.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-30.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-30.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-31.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-31.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-32.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-32.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-33.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-33.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-34.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-34.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-35.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-35.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-36.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-36.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-37.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-37.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-38.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-38.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-39.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-39.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-4.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-40.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-40.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-41.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-41.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-42.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-42.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-43.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-43.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-44.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-44.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-45.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-45.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-46.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-46.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-47.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-47.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-48.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-48.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-49.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-49.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-5.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-50.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-50.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-51.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-51.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-52.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-52.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-53.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-53.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-54.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-54.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-55.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-55.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-56.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-56.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-57.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-57.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-58.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-58.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-59.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-59.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-6.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-60.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-60.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-61.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-61.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-62.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-62.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-63.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-63.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-64.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-64.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-65.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-65.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-66.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-66.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-67.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-67.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-68.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-68.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-69.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-69.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-7.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-70.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-70.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-71.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-71.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-72.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-72.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-73.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-73.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-74.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-74.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-75.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-75.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-76.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-76.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-77.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-77.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-78.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-78.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-79.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-79.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-8.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-80.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-80.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-81.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-81.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-82.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-82.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-83.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-83.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-84.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-84.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-85.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-85.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-86.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-86.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-87.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-87.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-88.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-88.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-89.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-89.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-9.c
@@ -82,4 +82,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-90.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-90.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-91.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-91.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-92.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-92.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-93.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-93.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-94.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-94.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-95.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-95.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-96.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-96.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-97.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-97.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-98.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-98.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-99.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/4-99.c
@@ -38,4 +38,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-1.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-10.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-11.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-12.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-13.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-14.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-15.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-16.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-17.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-18.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-19.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-2.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-20.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-21.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-22.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-23.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-24.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-25.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-26.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-3.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-4.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-5.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-6.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-7.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-8.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/6-9.c
@@ -55,4 +55,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-1.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-10.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-10.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-11.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-11.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-12.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-12.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-13.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-13.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-14.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-14.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-15.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-15.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-16.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-16.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-17.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-17.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-18.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-18.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-19.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-19.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-2.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-20.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-20.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-21.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-21.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-22.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-22.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-23.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-23.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-24.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-24.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-25.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-25.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-26.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-26.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-3.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-4.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-4.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-5.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-5.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-6.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-7.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-7.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-8.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-8.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-9.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/8-9.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/9-1.c
@@ -103,4 +103,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return -1;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigdelset/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigdelset/4-1.c
@@ -24,6 +24,8 @@
 
 static const int sigs[] = {-1, -10000, INT32_MIN, INT32_MIN + 1};
 
+#define	NUMSIGNALS	(sizeof(sigs) / sizeof(sigs[0]))
+
 int main(void)
 {
 	sigset_t signalset;
@@ -34,9 +36,8 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
-	for (i = 0; i < sizeof(sigs) / sizeof(int); i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		ret = sigdelset(&signalset, sigs[i]);
-	
 		if (ret != -1 || errno != EINVAL) {
 			err++;
 			printf("Failed sigdelset(..., %i) ret=%i errno=%i\n",

--- a/testcases/open_posix_testsuite/conformance/interfaces/sighold/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sighold/3-1.c
@@ -21,11 +21,13 @@
 
 static const int sigs[] = {-1, -10000, INT32_MIN, INT32_MIN + 1};
 
+#define	NUMSIGNALS	(sizeof(sigs) / sizeof(sigs[0]))
+
 int main(void)
 {
 	int i, ret, err = 0;
 
-	for (i = 0; i < sizeof(sigs) / sizeof(int); i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		ret = sighold(sigs[i]);
 
 		if (ret != -1 || errno != EINVAL) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigignore/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigignore/5-1.c
@@ -20,11 +20,13 @@
 
 static const int sigs[] = {-1, -10000, INT32_MIN, INT32_MIN + 1};
 
+#define	NUMSIGNALS	(sizeof(sigs) / sizeof(sigs[0]))
+
 int main(void)
 {
 	int i, ret, err = 0;
 
-	for (i = 0; i < sizeof(sigs) / sizeof(int); i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		ret = sigignore(sigs[i]);
 
 		if (ret != -1 || errno != EINVAL) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigismember/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigismember/5-1.c
@@ -23,6 +23,8 @@
 
 static const int sigs[] = {-1, -10000, INT32_MIN, INT32_MIN + 1};
 
+#define	NUMSIGNALS	(sizeof(sigs) / sizeof(sigs[0]))
+
 int main(void)
 {
 	sigset_t signalset;
@@ -33,7 +35,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
-	for (i = 0; i < sizeof(sigs) / sizeof(int); i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		ret = sigismember(&signalset, sigs[i]);
 
 		if (ret != -1 || errno != EINVAL) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/signal/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/signal/1-1.c
@@ -51,4 +51,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/signal/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/signal/2-1.c
@@ -50,4 +50,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/signal/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/signal/3-1.c
@@ -43,4 +43,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/12-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/12-1.c
@@ -44,7 +44,7 @@ int is_changed(sigset_t set)
 		SIGTRAP, SIGURG, SIGVTALRM, SIGXCPU, SIGXFSZ
 	};
 
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if (sigismember(&set, siglist[i]) != 0)
 			return 1;
 	}

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/4-1.c
@@ -84,4 +84,3 @@ int main(void)
 	printf("Test PASSED: signal was added to the process's signal mask\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/5-1.c
@@ -72,4 +72,3 @@ int main(void)
 	printf("Test PASSED: signal was added to the process's signal mask\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/6-1.c
@@ -105,4 +105,3 @@ int main(void)
 	printf("Test PASSED: signal was added to the process's signal mask\n");
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/7-1.c
@@ -41,7 +41,7 @@ int main(void)
 		SIGTRAP, SIGURG, SIGVTALRM, SIGXCPU, SIGXFSZ
 	};
 
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		sigemptyset(&oactl);
 		sigemptyset(&tempset);
 		sigaddset(&tempset, siglist[i]);

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/8-1.c
@@ -43,7 +43,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/8-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/8-2.c
@@ -44,7 +44,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/8-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/8-3.c
@@ -43,7 +43,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigprocmask/9-1.c
@@ -83,4 +83,3 @@ int main(void)
 	    ("Test PASSED: signal was delivered before the call to sigprocmask returned.\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/1-1.c
@@ -87,4 +87,3 @@ int main(void)
 	printf("Test FAILED\n");
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/4-1.c
@@ -29,9 +29,11 @@
 #include <errno.h>
 #include "posixtest.h"
 
-int counter = 0;
+static volatile int counter;
 
-void myhandler(int signo, siginfo_t * info, void *context)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED,
+	siginfo_t *info LTP_ATTRIBUTE_UNUSED,
+	void *context LTP_ATTRIBUTE_UNUSED)
 {
 	counter++;
 }

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/6-1.c
@@ -34,10 +34,12 @@
 #include <errno.h>
 #include "posixtest.h"
 
-int return_val = 1;
-int handler_called = 0;
+static int return_val = 1;
+static volatile int handler_called;
 
-void myhandler(int signo, siginfo_t * info, void *context)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED,
+	siginfo_t *info LTP_ATTRIBUTE_UNUSED,
+	void *context LTP_ATTRIBUTE_UNUSED)
 {
 	handler_called = 1;
 	if (return_val != 1) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/7-1.c
@@ -31,10 +31,11 @@
 #include <errno.h>
 #include "posixtest.h"
 
-int last_signal = 0;
-int test_failed = 0;
+static int last_signal;
+static volatile int test_failed;
 
-void myhandler(int signo, siginfo_t * info, void *context)
+void myhandler(int signo, siginfo_t *info LTP_ATTRIBUTE_UNUSED,
+	void *context LTP_ATTRIBUTE_UNUSED)
 {
 	printf("%d, ", signo);
 	if (last_signal >= signo) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/8-1.c
@@ -30,9 +30,11 @@
 #include <errno.h>
 #include "posixtest.h"
 
-int counter = 0;
+static volatile int counter;
 
-void myhandler(int signo, siginfo_t * info, void *context)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED,
+	siginfo_t *info LTP_ATTRIBUTE_UNUSED,
+	void *context LTP_ATTRIBUTE_UNUSED)
 {
 	counter++;
 }

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigrelse/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigrelse/3-1.c
@@ -24,11 +24,13 @@
 
 static const int sigs[] = {-1, -10000, INT32_MIN, INT32_MIN + 1};
 
+#define	NUMSIGNALS	(sizeof(sigs) / sizeof(sigs[0]))
+
 int main(void)
 {
 	int i, ret, err = 0;
 
-	for (i = 0; i < sizeof(sigs) / sizeof(int); i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		ret = sigrelse(sigs[i]);
 
 		if (ret != -1 || errno != EINVAL) {

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/1-1.c
@@ -58,4 +58,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/1-1.c
@@ -23,9 +23,9 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-int handler_called = 0;
+static volatile int handler_called;
 
-void myhandler(int signo)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("SIGCHLD called. Inside handler\n");
 	handler_called = 1;
@@ -58,3 +58,4 @@ int main(void)
 	}
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/2-1.c
@@ -22,9 +22,9 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-int handler_called = 0;
+static volatile int handler_called;
 
-void myhandler(int signo)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("SIGUSR1 called. Inside handler\n");
 	handler_called = 1;
@@ -56,3 +56,4 @@ int main(void)
 	}
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/2-1.c
@@ -56,4 +56,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/3-1.c
@@ -20,9 +20,9 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-int handler_called = 0;
+static volatile int handler_called;
 
-void myhandler(int signo)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("SIGCHLD called. Inside handler\n");
 	handler_called = 1;
@@ -44,3 +44,4 @@ int main(void)
 	}
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/3-1.c
@@ -44,4 +44,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/4-1.c
@@ -18,7 +18,7 @@
 
 int signal_blocked = 0;
 
-void myhandler(int signo)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("SIGCHLD called. Inside handler\n");
 	sigset_t mask;
@@ -44,3 +44,4 @@ int main(void)
 	}
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/4-1.c
@@ -44,4 +44,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/5-1.c
@@ -78,4 +78,3 @@ int main(void)
 	}
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/5-1.c
@@ -43,14 +43,14 @@ int is_empty(sigset_t * set)
 		SIGTRAP, SIGURG, SIGVTALRM, SIGXCPU, SIGXFSZ
 	};
 
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if (sigismember(set, siglist[i]) != 0)
 			return 0;
 	}
 	return 1;
 }
 
-void myhandler(int signo)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 }
 
@@ -78,3 +78,4 @@ int main(void)
 	}
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/6-1.c
@@ -27,7 +27,7 @@
 #define ERR_MSG(f, rc) printf("Failed: func: %s rc: %u errno: %s\n", \
 						f, rc, strerror(errno))
 
-void myhandler(int signo)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("SIGCHLD called. Inside handler\n");
 }
@@ -68,3 +68,4 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/6-1.c
@@ -68,4 +68,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/7-1.c
@@ -84,4 +84,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/7-1.c
@@ -34,7 +34,7 @@
 
 static int handler_called;
 
-static void myhandler(int signo)
+static void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	handler_called = 1;
 }
@@ -84,3 +84,4 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/9-1.c
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-void myhandler(int signo)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("SIGUSR1 called. Inside handler\n");
 }
@@ -41,3 +41,4 @@ int main(void)
 
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigset/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigset/9-1.c
@@ -41,4 +41,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigsuspend/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigsuspend/4-1.c
@@ -35,7 +35,7 @@
 
 #define NUMSIGNALS (sizeof(siglist) / sizeof(siglist[0]))
 
-void handler(int signo)
+void handler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 }
 
@@ -61,7 +61,7 @@ int is_changed(sigset_t set, int sig)
 	if (sigismember(&set, sig) != 1) {
 		return 1;
 	}
-	for (i = 0; i < NUMSIGNALS; i++) {
+	for (i = 0; i < (int)NUMSIGNALS; i++) {
 		if ((siglist[i] != sig)) {
 			if (sigismember(&set, siglist[i]) != 0) {
 				return 1;

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigwaitinfo/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigwaitinfo/3-1.c
@@ -100,4 +100,3 @@ int main(void)
 		return PTS_PASS;
 	}
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigwaitinfo/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigwaitinfo/7-1.c
@@ -85,4 +85,3 @@ int main(void)
 
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigwaitinfo/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigwaitinfo/7-1.c
@@ -30,9 +30,11 @@
 #include <errno.h>
 #include "posixtest.h"
 
-int counter = 0;
+int counter;
 
-void myhandler(int signo, siginfo_t * info, void *context)
+void myhandler(int signo LTP_ATTRIBUTE_UNUSED,
+	siginfo_t *info LTP_ATTRIBUTE_UNUSED,
+	void *context LTP_ATTRIBUTE_UNUSED)
 {
 	counter++;
 }
@@ -83,3 +85,4 @@ int main(void)
 
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/strlen/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/strlen/1-1.c
@@ -51,7 +51,7 @@ int main(void)
 		ret_str = random_string(i);
 		obtained_len = strlen(ret_str);
 
-		if (obtained_len != i) {
+		if (obtained_len != (size_t)i) {
 			printf(TNAME " Test Failed, return value is not as expected, "
 					"for the given string. Expected string length: %d,"
 					" But got: %zu.\n", i, obtained_len);

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/1-1.c
@@ -95,4 +95,3 @@ int main(void)
 	       (int)ts.tv_sec - (int)tsleft.tv_sec, TIMERSEC);
 	return PTS_FAIL;
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/1-1.c
@@ -34,7 +34,7 @@
 #define SLEEPDELTA 3
 #define ACCEPTABLEDELTA 1
 
-void handler(int signo)
+void handler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("Caught signal\n");
 }
@@ -85,7 +85,7 @@ int main(void)
 		return PTS_FAIL;
 	}
 
-	if (abs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
+	if (labs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
 		printf("Test PASSED\n");
 		return PTS_PASS;
 	}
@@ -95,3 +95,4 @@ int main(void)
 	       (int)ts.tv_sec - (int)tsleft.tv_sec, TIMERSEC);
 	return PTS_FAIL;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/10-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/10-1.c
@@ -106,4 +106,3 @@ int main(void)
 	return PTS_FAIL;
 #endif
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/10-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/10-1.c
@@ -23,7 +23,7 @@
 
 static volatile int caught_signal;
 
-static void handler(int signo)
+static void handler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	caught_signal = 1;
 }
@@ -94,7 +94,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
-	if (abs(ts_end.tv_sec - ts_start.tv_sec - TIMERSEC) <= ACCEPTABLEDELTA) {
+	if (labs(ts_end.tv_sec - ts_start.tv_sec - TIMERSEC) <= ACCEPTABLEDELTA) {
 		printf("Test PASSED\n");
 		return PTS_PASS;
 	}
@@ -106,3 +106,4 @@ int main(void)
 	return PTS_FAIL;
 #endif
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/11-1.c
@@ -106,4 +106,3 @@ int main(void)
 	return PTS_FAIL;
 #endif
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/11-1.c
@@ -23,7 +23,7 @@
 
 static volatile int caught_signal;
 
-static void handler(int signo)
+static void handler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	caught_signal = 1;
 }
@@ -94,7 +94,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
-	if (abs(ts_end.tv_sec - ts_start.tv_sec - TIMERSEC) <= ACCEPTABLEDELTA) {
+	if (labs(ts_end.tv_sec - ts_start.tv_sec - TIMERSEC) <= ACCEPTABLEDELTA) {
 		printf("Test PASSED\n");
 		return PTS_PASS;
 	}
@@ -106,3 +106,4 @@ int main(void)
 	return PTS_FAIL;
 #endif
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/7-1.c
@@ -97,4 +97,3 @@ int main(void)
 #endif
 
 }
-

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/7-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/7-1.c
@@ -24,7 +24,7 @@
 #define SLEEPDELTA 3
 #define ACCEPTABLEDELTA 1
 
-void handler(int signo)
+void handler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("Caught signal\n");
 }
@@ -80,7 +80,7 @@ int main(void)
 		return PTS_FAIL;
 	}
 
-	if (abs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
+	if (labs(tsleft.tv_sec - SLEEPDELTA) <= ACCEPTABLEDELTA) {
 		printf("Test PASSED\n");
 		return PTS_PASS;
 	} else {
@@ -97,3 +97,4 @@ int main(void)
 #endif
 
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/speculative/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/speculative/2-1.c
@@ -52,7 +52,7 @@ int main(void)
 		return PTS_UNRESOLVED;
 	}
 
-	for (i = 0; i < max; i++) {
+	for (i = 0; (int)i < max; i++) {
 		if (timer_create(CLOCK_REALTIME, &ev, &tid) != 0) {
 #ifndef TIMER_MAX
 			if (errno == EAGAIN)

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/speculative/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/speculative/5-1.c
@@ -42,7 +42,7 @@
 #define SLEEPDELTA 3
 #define ACCEPTABLEDELTA 1
 
-void handler(int signo)
+void handler(int signo LTP_ATTRIBUTE_UNUSED)
 {
 	printf("Caught signal\n");
 }
@@ -91,7 +91,7 @@ int main(void)
 	}
 	// Test can validly fail if timer did not last for correct amount
 	// of time, but nanosleep() was interrupted.
-	if (abs(tsleft.tv_sec - SLEEPDELTA) > ACCEPTABLEDELTA) {
+	if (labs(tsleft.tv_sec - SLEEPDELTA) > ACCEPTABLEDELTA) {
 		printf("Timer did not last for correct amount of time\n");
 		printf("timer: %d != correct %d\n",
 		       (int)ts.tv_sec - (int)tsleft.tv_sec, TIMERSEC);
@@ -101,3 +101,4 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
+

--- a/testcases/open_posix_testsuite/conformance/interfaces/timer_create/speculative/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/timer_create/speculative/5-1.c
@@ -101,4 +101,3 @@ int main(void)
 	printf("Test PASSED\n");
 	return PTS_PASS;
 }
-

--- a/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c
+++ b/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c
@@ -117,11 +117,11 @@ int main(void)
 	mqstat.mq_msgsize = MSG_SIZE;
 	mqstat.mq_flags = 0;
 
-	if ((mq1 = mq_open(MQ_NAME_1, oflag, 0777, &mqstat)) == -1) {
+	if ((mq1 = mq_open(MQ_NAME_1, oflag, 0777, &mqstat)) == (mqd_t)-1) {
 		printf("mq_open doesn't return success \n");
 		return PTS_UNRESOLVED;
 	}
-	if ((mq2 = mq_open(MQ_NAME_2, oflag, 0777, &mqstat)) == -1) {
+	if ((mq2 = mq_open(MQ_NAME_2, oflag, 0777, &mqstat)) == (mqd_t)-1) {
 		printf("mq_open doesn't return success \n");
 		return PTS_UNRESOLVED;
 	}

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
@@ -325,4 +325,3 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread \n");
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
@@ -359,4 +359,3 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread \n");
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
@@ -371,4 +371,3 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread\n");
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
@@ -335,4 +335,3 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread\n");
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
@@ -343,4 +343,3 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread\n");
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
@@ -326,4 +326,3 @@ int main(void)
 	DPRINTF(stderr, "Main Thread: stop sampler thread\n");
 	return 0;
 }
-

--- a/testcases/open_posix_testsuite/include/affinity.h
+++ b/testcases/open_posix_testsuite/include/affinity.h
@@ -25,7 +25,6 @@
 
 #ifdef __linux__
 # define _GNU_SOURCE
-# define AFFINITY_NEEDS_GNU_SOURCE 1
 # include <sched.h>
 # include <stdio.h>
 

--- a/testcases/open_posix_testsuite/include/posixtest.h
+++ b/testcases/open_posix_testsuite/include/posixtest.h
@@ -10,30 +10,6 @@
  * return codes
  */
 
-/*
- * Define PTS_DEVELOPER_MODE if you want to compile for developer scenarios,
- * including reporting errors (as opposed to warnings), when compiling some
- * test programs.
- */
-
-#if defined(_GNU_SOURCE)
-# if !AFFINITY_NEEDS_GNU_SOURCE
-#  if defined(PTS_DEVELOPER_MODE)
-#   error "Contains GNU-isms that need fixing."
-#  else
-#   warning "Contains GNU-isms that need fixing."
-#  endif
-# endif
-#endif
-
-#if defined(_BSD_SOURCE)
-# if defined(PTS_DEVELOPER_MODE)
-#  error "Contains BSD-isms that need fixing."
-# else
-#  warning "Contains BSD-isms that need fixing."
-# endif
-#endif
-
 #define PTS_PASS        0
 #define PTS_FAIL        1
 #define PTS_UNRESOLVED  2

--- a/testcases/open_posix_testsuite/include/timespec.h
+++ b/testcases/open_posix_testsuite/include/timespec.h
@@ -35,5 +35,5 @@ static long timespec_nsec_diff(struct timespec *t1, struct timespec *t2)
 	if (sec_diff > 1 || (sec_diff == 1 && nsec_diff >= 0))
 		return NSEC_IN_SEC;
 
-	return abs(nsec_diff + NSEC_IN_SEC * sec_diff);
+	return labs(nsec_diff + NSEC_IN_SEC * sec_diff);
 }

--- a/testcases/open_posix_testsuite/stress/mqueues/multi_send_rev_1.c
+++ b/testcases/open_posix_testsuite/stress/mqueues/multi_send_rev_1.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
 	mqstat.mq_flags = 0;
 
 	for (i = 0; i < num; i++) {
-		if ((mq[i] = mq_open(MQ_NAME[i], oflag, 0777, &mqstat)) == -1) {
+		if ((mq[i] = mq_open(MQ_NAME[i], oflag, 0777, &mqstat)) == (mqd_t)-1) {
 			perror("mq_open doesn't return success \n");
 			return PTS_UNRESOLVED;
 		}

--- a/testcases/open_posix_testsuite/stress/mqueues/multi_send_rev_2.c
+++ b/testcases/open_posix_testsuite/stress/mqueues/multi_send_rev_2.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
 	mqstat.mq_msgsize = MSG_SIZE;
 	mqstat.mq_flags = 0;
 
-	if ((mq = mq_open(MQ_NAME, oflag, 0777, &mqstat)) == -1) {
+	if ((mq = mq_open(MQ_NAME, oflag, 0777, &mqstat)) == (mqd_t)-1) {
 		printf("mq_open doesn't return success\n");
 		return PTS_UNRESOLVED;
 	}

--- a/testcases/open_posix_testsuite/stress/signals/sigismember_stress_1.c
+++ b/testcases/open_posix_testsuite/stress/signals/sigismember_stress_1.c
@@ -21,6 +21,7 @@ int main()
 	sigset_t signalset;
 	int returnval;
 	returnval = sigismember(&signalset, SIGALRM);
+	(void)returnval;
 
 #ifdef DEBUG
 	printf("sigismember returned returnval\n");


### PR DESCRIPTION
This PR when compared with #471, #472, and #473 focuses on a different hodgepodge of warnings/supersets of the previous PRs.

This PR also focuses on correctness issues with some of the tests which rely on signal handling, in particular dealing with variables not being properly annotated with `volatile`, which was touched on in #472.

One point of interest is that this PR also takes a stab at fixing some of the tests that rely on `mq_open(..)` on FreeBSD, as FreeBSD defines `mqd_t` as a pointer to a struct, whereas Linux defines it as a simple integral value. This PR doesn't address all of the issues, but it addresses some of the issues.