### PR TITLE
perf_event_open02: Add s390 specifics

### DIFF
--- a/testcases/kernel/syscalls/perf_event_open/perf_event_open02.c
+++ b/testcases/kernel/syscalls/perf_event_open/perf_event_open02.c
@@ -82,7 +82,6 @@ int TST_TOTAL = 1;
 #define MAX_CTRS	1000
 #define LOOPS		100000000
 
-static int count_hardware_counters(void);
 static void setup(void);
 static void verify(void);
 static void cleanup(void);
@@ -142,6 +141,7 @@ struct read_format {
 	unsigned long long time_running;
 };
 
+#ifndef __s390__
 static int count_hardware_counters(void)
 {
 	struct perf_event_attr hw_event;
@@ -215,6 +215,7 @@ static int count_hardware_counters(void)
 
 	return hwctrs;
 }
+#endif
 
 static void setup(void)
 {
@@ -233,8 +234,19 @@ static void setup(void)
 
 	TEST_PAUSE;
 
+#ifdef __s390__
+	/*
+	 * On s390 the "time_enabled" and "time_running" values are always the
+	 * same, therefore count_hardware_counters() does not work.
+	 *
+	 * There are distinct/dedicated counters that can be used independently.
+	 * Use the dedicated counter for instructions here.
+	 */
+	n = nhw = 1;
+#else
 	nhw = count_hardware_counters();
 	n = nhw + 4;
+#endif
 
 	memset(&hw_event, 0, sizeof(struct perf_event_attr));
 	memset(&tsk_event, 0, sizeof(struct perf_event_attr));


### PR DESCRIPTION
Currently the testcase fails on s390 LPARs with enabled Counter Facility as follows:

```
 perf_event_open02    0  TINFO  :  overall task clock: 43324672
 perf_event_open02    0  TINFO  :  hw sum: 801984103, task clock sum: 168166146
 perf_event_open02    0  TINFO  :  ratio: 3.881533
 perf_event_open02    1  TFAIL  :  perf_event_open02.c:346: test failed (ratio was greater than )
```

On s390 "buf.time_enabled" is always equal to "buf.time_running", therefore count_hardware_counters() loops 1000 (MAX_CTRS) times and then returns 0.

The Counter facility on s390 provides numerous counters that are dedicated to measure a specific activity, for example, instructions. Unlike other architectures, it is not required to program a PMU and, thus, there are no issues with counter constraints and multiplexing.

Therefore, adapt the test case to ignore multiplexing logic for s390 and make the testcase work:

```
 perf_event_open02    0  TINFO  :  overall task clock: 61093214
 perf_event_open02    0  TINFO  :  hw sum: 200320299, task clock sum: 61091488
 perf_event_open02    0  TINFO  :  ratio: 0.999972
 perf_event_open02    1  TPASS  :  test passed
```

Signed-off-by: Michael Holzheu <holzheu@linux.ibm.com>
Reviewed-by: Hendrik Brueckner <brueckner@linux.ibm.com>