### PR TITLE
FSCANF PR 2:Adds conformance tests for fscanf

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/15-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/15-1.c
@@ -1,0 +1,105 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hhd" specifier is specified, signed char(base argument is 10) is
+ *	read from the named input stream in sequence, bytes are read in
+ *	sequence and result is stored in the arguments. Function call expects
+ *	a control string format and a set of pointer arguments indicating
+ *	where the converted input is stored
+ *
+ * method:
+ *	-open file in write mode
+ *	-write 3 sample integers into the file corresponding to min, max and
+ *	 a midrange value of signed short short decimal integer
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier "%hhd"
+ *	-compare the values read into the arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/15-1.c"
+#define FNAME "in_file"
+#define SCHAR_CONST_VALUE 10
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	signed char min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%hhd %hhd %hhd", SCHAR_MAX, SCHAR_MIN,
+		      SCHAR_CONST_VALUE);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	ret = fscanf(in_fp, "%hhd %hhd %hhd",
+				&max_value, &min_value, &mid_value);
+	remove_file(in_fp);
+	if (ret == 3 && max_value == SCHAR_MAX && min_value == SCHAR_MIN &&
+	    mid_value == SCHAR_CONST_VALUE) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %hhd, "
+			"min_value = %hhd, mid_value = %hhd\n\t\t\tObtained values: "
+			"ret = %d, max_value = %hhd, min_value = %hhd, "
+			"mid_value = %hhd\n", SCHAR_MAX, SCHAR_MIN,
+			SCHAR_CONST_VALUE, ret, max_value, min_value,
+			mid_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/16-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/16-1.c
@@ -1,0 +1,105 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hhi" specifier is specified, signed char(base argument is 0) is
+ *	read from the named input stream in sequence, bytes are read in
+ *	sequence and result is stored in the arguments. Function call expects
+ *	a control string format and a set of pointer arguments indicating where
+ *	the converted input is stored.
+ *
+ * method:
+ *	-open a file in write mode
+ *	-write 3 sample integers into the file corresponding to min, max
+ *	 and midrange values of signed short short integer
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier "%hhi"
+ *	-compare the values read into the arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/16-1.c"
+#define FNAME "in_file"
+#define SCHAR_CONST_VALUE 123
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	signed char min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%hhi 0x%hhx 0%hho", SCHAR_MIN, SCHAR_MAX,
+		      SCHAR_CONST_VALUE);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	ret = fscanf(in_fp, "%hhi %hhi %hhi",
+				&min_value, &max_value, &mid_value);
+	remove_file(in_fp);
+	if (ret == 3 && min_value == SCHAR_MIN && max_value == SCHAR_MAX &&
+	    mid_value == SCHAR_CONST_VALUE) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %hhi, "
+			"min_value = %hhi, mid_value = %hhi\n\t\t\t"
+			"Obtained values: ret = %d, max_value = %hhi, min_value = %hhi, "
+			"mid_value = %hhi\n", SCHAR_MAX, SCHAR_MIN,
+			SCHAR_CONST_VALUE, ret, max_value, min_value,
+			mid_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/17-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/17-1.c
@@ -1,0 +1,106 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hho" specifier is specified, unsigned char(base argument is 8) is
+ *	read from the named input stream in sequence, bytes are read in sequence
+ *	and result is stored in the arguments. Function call expects a control
+ *	string format and a set of pointer arguments indicating where the
+ *	converted input is stored.
+ *
+ * method:
+ *	-open file in write mode
+ *	-write 3 sample integers into the file corresponding to min, max and
+ *	 a midrange value of unsigned short short octal integer
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier %hho"
+ *	-compare the values read into corresponding arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/17-1.c"
+#define FNAME "in_file.txt"
+#define UCHAR_MIN_VALUE 0
+#define UCHAR_CONST_VALUE 10
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	unsigned char min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%hho %hho %hho", UCHAR_MAX, UCHAR_MIN_VALUE,
+		      UCHAR_CONST_VALUE);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	ret = fscanf(in_fp, "%hho %hho %hho",
+				&max_value, &min_value, &mid_value);
+	remove_file(in_fp);
+	if (ret == 3 && min_value == UCHAR_MIN_VALUE &&
+		max_value == UCHAR_MAX &&
+	    mid_value == UCHAR_CONST_VALUE) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %hho, "
+			"min_value = %hho, mid_value = %hho\n\t\t\tObtained values: "
+			"ret = %d, max_value = %hho, min_value = %hho, mid_value = %hho\n",
+			UCHAR_MAX, UCHAR_MIN_VALUE, UCHAR_CONST_VALUE, ret,
+			max_value, min_value, mid_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/18-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/18-1.c
@@ -1,0 +1,106 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hhu" specifier is specified, unsigned char(base argument is 10)
+ *	is read from the named input stream in sequence, bytes are read in
+ *	sequence and result is stored in the arguments. Function call expects
+ *	a control string format and a set of pointer arguments indicating where
+ *	the converted input is stored.
+ *
+ * method:
+ *	-open file in write mode
+ *	-write a 3 sample integer into the file corresponding to min, max and
+ *	 a midrange value of unsigned short short decimal integer
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf ()and conversion specifier "%hhu"
+ *	-compare the values read into the arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/18-1.c"
+#define FNAME "in_file"
+#define UCHAR_MIN_VALUE 0
+#define UCHAR_CONST_VALUE 10
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	unsigned char min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%hhu %hhu %hhu", UCHAR_MIN_VALUE, UCHAR_MAX,
+		      UCHAR_CONST_VALUE);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	ret = fscanf(in_fp, "%hhu %hhu %hhu",
+				&min_value, &max_value, &mid_value);
+	remove_file(in_fp);
+	if (ret == 3 && max_value == UCHAR_MAX &&
+		min_value == UCHAR_MIN_VALUE &&
+	    mid_value == UCHAR_CONST_VALUE) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %hhu, "
+			"min_value = %hhu, mid_value = %hhu\n\t\t\tObtained values: "
+			"ret = %d, max_value = %hhu, min_value = %hhu, mid_value = %hhu\n",
+			UCHAR_MAX, UCHAR_MIN_VALUE, UCHAR_CONST_VALUE,
+			ret, max_value, min_value, mid_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/19-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/19-1.c
@@ -1,0 +1,106 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hhx" specifier is specified, unsigned char(base argument is 16)
+ *	is read from the named input stream in sequence, bytes are read in
+ *	sequence and result is stored in the arguments. Function call expects
+ *	a control string format and a set of pointer arguments indicating where
+ *	the converted input is stored.
+ *
+ * method:
+ *	-open file in write mode
+ *	-write 3 ineger values corresponding to max value, min value and
+ *	 mid range value of unsigned short short hexadecimal integer.
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier "%hhx"
+ *	-compare the values read into the arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/19-1.c"
+#define FNAME "in_file"
+#define UCHAR_MIN_VALUE 0
+#define UCHAR_CONST_VALUE 16
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	unsigned char min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%hhx %hhx %hhx", UCHAR_MIN_VALUE, UCHAR_MAX,
+		      UCHAR_CONST_VALUE);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	ret = fscanf(in_fp, "%hhx %hhx %hhx",
+				&min_value, &max_value, &mid_value);
+	remove_file(in_fp);
+	if (ret == 3 && min_value == UCHAR_MIN_VALUE &&
+		max_value == UCHAR_MAX &&
+	    mid_value == UCHAR_CONST_VALUE) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %hhx, "
+			"min_value = %hhx, mid_value = %hhx\n\t\t\tObtained values: "
+			"ret = %d, max_value = %hhx, min_value = %hhx, mid_value = %hhx\n",
+			UCHAR_MAX, UCHAR_MIN_VALUE, UCHAR_CONST_VALUE, ret,
+			max_value, min_value, mid_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/20-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/20-1.c
@@ -1,0 +1,107 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hhX" specifier is specified, unsigned char(base argument is 16)
+ *	is read from the named input stream in sequence, bytes are read in
+ *	sequence and result is stored in the arguments. Function call expects a
+ *	control string format and a set of pointer arguments indicating where
+ *	the converted input is stored.
+ *
+ * method:
+ *	-open file in write mode
+ *	-write 3 ineger values corresponding to max value, min value and
+ *	 mid range value of unsigned short short hexadecimal integer.
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier "%hhX"
+ *	-compare the values read into the arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/20-1.c"
+#define FNAME "in_file"
+#define UCHAR_MIN_VALUE 0
+#define UCHAR_CONST_VALUE 10
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	unsigned char min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%hhX %hhX %hhX", UCHAR_MIN_VALUE, UCHAR_MAX,
+		      UCHAR_CONST_VALUE);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	ret = fscanf(in_fp, "%hhX %hhX %hhX",
+				&min_value, &max_value, &mid_value);
+	remove_file(in_fp);
+	if (ret == 3 && min_value == UCHAR_MIN_VALUE &&
+		max_value == UCHAR_MAX &&
+	    mid_value == UCHAR_CONST_VALUE) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %hhX, "
+			"min_value = %hhX, mid_value = %hhX\n\t\t\t"
+			"Obtained values: ret = %d, max_value = %hhX, "
+			"min_value = %hhX, mid_value = %hhX\n", UCHAR_MAX,
+			UCHAR_MIN_VALUE, UCHAR_CONST_VALUE, ret, max_value,
+			min_value, mid_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/21-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/21-1.c
@@ -1,0 +1,114 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hhn" specifier is specified, data is read from the named
+ *	input stream in sequence, interprets the bytes in sequence according
+ *	to the directive format specified before "%hhn" directive, and stores
+ *	the result in its arguments. Number of bytes read by fscanf() so far
+ *	are written to the argument corresponding to "%hhn" directive.
+ *	Directives specified after "%hhn" are converted but they don't account
+ *	for the length calculated in "%hhn" directive.
+ *
+ * method:
+ *	-open file in write mode
+ *	-write a 3 sample strings into the file each seperated by whitespace
+ *	character
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf and conversion specifier "%hhn"
+ *	-compare the number of bytes read into argument corresponding to first
+ *	 "%hhn" with length of first string and that corresponding to second
+ *	"%hhn"  with length of first string + length of second string +1. Reason
+ *	for adding  1 is that "%hhn" will consume whitespace character.
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/21-1.c"
+#define FNAME "in_file"
+#define STRING_CONST1 "POSIX"
+#define STRING_CONST2 "CONFORMANCE"
+#define STRING_CONST3 "TEST"
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	unsigned char byte_count1 = 0, byte_count2 = 0;
+	unsigned char total_byte_count = 0;
+	int ret = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%s %s %s", STRING_CONST1, STRING_CONST2,
+		      STRING_CONST3);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	ret = fscanf(in_fp, "%*s%hhn%*s%hhn%*s", &byte_count1, &byte_count2);
+	remove_file(in_fp);
+
+	total_byte_count = strlen(STRING_CONST1) + strlen(STRING_CONST2) + 1;
+	if (ret == 0 && byte_count1 == (strlen(STRING_CONST1)) &&
+	    byte_count2 == total_byte_count) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Number of bytes read by %%hn  after reading "
+			"string_const1 = %hhd and string_const2 = %hhd when the "
+			"expected value of byte count after reading "
+			"string_const1 = %hhd and string_const2 = %hhd\n",
+			byte_count1, total_byte_count,
+			strlen(STRING_CONST1), total_byte_count);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/22-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/22-1.c
@@ -1,0 +1,107 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hd" specifier is specified, signed short integer(base argument
+ *	10) is read from the named input stream in sequence, bytes are read in
+ *	sequence and result is stored in the arguments. Function call expects
+ *	a control string format and a set of pointer arguments indicating where
+ *	the converted input is stored.
+ *
+ * method:
+ *	-open file in write mode
+ *	-write 3 sample integers into the file corresponding to min, max and
+ *	 a midrange value of signed short decimal integer
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier "%hd"
+ *	-compare the values read into the arguments with input values
+ */
+
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/22-1.c"
+#define FNAME "in_file"
+#define SHORT_CONST 1000
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	signed short min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0, read_values = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%d %d %d", SHRT_MAX, SHRT_MIN,
+		      SHORT_CONST);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	read_values = fscanf(in_fp, "%hd %hd %hd ", &max_value, &min_value,
+				 &mid_value);
+	remove_file(in_fp);
+
+	if (read_values == 3 && max_value == SHRT_MAX &&
+		min_value == SHRT_MIN &&
+		mid_value == SHORT_CONST) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %d, "
+				"min_value = %d, mid_value = %d\n\t\t\tObtained values: "
+				"ret = %d, max_value = %d, min_value = %d, mid_value = %d\n",
+				SHRT_MAX, SHRT_MIN, SHORT_CONST,
+				ret, max_value, min_value, mid_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/23-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/23-1.c
@@ -1,0 +1,109 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%hi" specifier is specified, signed short integer(base argumnet
+ *	is 0) is read from the named input stream in sequence,bytes are read
+ *	in sequence and result is stored in the arguments. Function call
+ *	expects a control string format and a set of pointer arguments
+ *	indicating where the converted input is stored.
+ *
+ * method:
+ *	-open a file in write mode
+ *	-write 4 sample integers into the file: min and max values of
+ *	 signed short integer, an octal value and a hexadecimal value.
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier "%hi"
+ *	-compare the values read into the arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/23-1.c"
+#define FNAME "in_file"
+#define HEX_CONST 0xAF
+#define OCT_CONST 012
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	signed short min_value = 0, max_value = 0, hex_value = 0, oct_value = 0;
+	int ret = 0, read_values = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%d %d 0x%x 0%o ", SHRT_MIN, SHRT_MAX,
+				  HEX_CONST, OCT_CONST);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	read_values = fscanf(in_fp, "%hi %hi %hi %hi", &min_value, &max_value,
+						 &hex_value, &oct_value);
+	remove_file(in_fp);
+
+	if (read_values == 4 && min_value == SHRT_MIN &&
+		max_value == SHRT_MAX &&
+		hex_value == HEX_CONST && oct_value == OCT_CONST) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME "  Expected values: ret = 4, max_value = %d, "
+			"min_value = %d, hex_value = %x, oct_value = %o\n\t\t\t "
+			"Obtained values: ret = %d, max_value = %d, min_value = %d, "
+			"hex_value = %x, oct_value = %o\n",
+			SHRT_MAX, SHRT_MIN, HEX_CONST,
+			OCT_CONST, ret, max_value, min_value,
+			hex_value, oct_value);
+		exit(PTS_FAIL);
+	}
+}

--- a/testcases/open_posix_testsuite/conformance/interfaces/fscanf/24-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fscanf/24-1.c
@@ -1,0 +1,106 @@
+/*
+ * This file is licensed under the GPL license.  For the full content
+ * of this license, see the COPYING file at the top level of this
+ * source tree.
+ */
+
+/*
+ * assertion:
+ *
+ *	When "%ho" specifier is specified, unsigned short integer(base argument
+ *	is 8) is read from the named input stream in sequence, bytes are read
+ *	in sequence and result is stored in the arguments. Function call
+ *	expects a control string format and a set of pointer arguments
+ *	indicating where the converted input is stored.
+ *
+ * method:
+ *	-open file in write mode
+ *	-write 3 sample integers into the file corresponding to min, max and
+ *	 a midrange value of unsigned short octal integer
+ *	-close the file
+ *	-open the same file in read mode
+ *	-read data from the file using fscanf() and conversion specifier %ho"
+ *	-compare the values read into corresponding arguments with input values
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <limits.h>
+#include "posixtest.h"
+
+#define TNAME "fscanf/24-1.c"
+#define FNAME "in_file.txt"
+#define USHRT_MIN 0
+#define OCT_CONST 010
+
+static void remove_file(FILE *in_fp)
+{
+	errno = 0;
+	if (in_fp != NULL) {
+		if (fclose(in_fp) == EOF) {
+			printf(TNAME " Error at fclose(), errno = %d\n", errno);
+			unlink(FNAME);
+			exit(PTS_UNRESOLVED);
+		}
+	}
+	unlink(FNAME);
+}
+
+int main(void)
+{
+	FILE *in_fp = NULL;
+	unsigned short min_value = 0, max_value = 0, mid_value = 0;
+	int ret = 0, read_values = 0;
+
+	errno = 0;
+
+	in_fp = fopen(FNAME, "w");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		exit(PTS_UNRESOLVED);
+	}
+
+	ret = fprintf(in_fp, "%o %o %o", USHRT_MAX, USHRT_MIN,
+					OCT_CONST);
+	if (ret < 0) {
+		printf(TNAME " Error at fprintf()\n");
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	if (fclose(in_fp) == EOF) {
+		printf(TNAME " Error at fclose(), errno = %d\n", errno);
+		unlink(FNAME);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	in_fp = fopen(FNAME, "r");
+	if (in_fp == NULL) {
+		printf(TNAME " Error at fopen(), errno = %d\n", errno);
+		remove_file(in_fp);
+		exit(PTS_UNRESOLVED);
+	}
+
+	errno = 0;
+	read_values = fscanf(in_fp, "%ho %ho %ho", &max_value, &min_value,
+						 &mid_value);
+	remove_file(in_fp);
+
+	if (read_values == 3 && min_value == USHRT_MIN && max_value == USHRT_MAX
+		&& mid_value == OCT_CONST) {
+		printf(TNAME " Test Passed\n");
+		exit(PTS_PASS);
+	} else {
+		printf(TNAME " Test Failed\n");
+		printf(TNAME " Expected values: ret = 3, max_value = %o, "
+			"min_value = %o, mid_value = %o\n\t\t\tObtained values: "
+			"ret = %d, max_value = %o, min_value = %o, mid_value = %o\n",
+			USHRT_MAX, USHRT_MIN, OCT_CONST, ret,
+			max_value, min_value, mid_value);
+		exit(PTS_FAIL);
+	}
+}


### PR DESCRIPTION
Adds a set of conformance testcases for fscanf

Signed-off-by: Ritul Jasuja <ritul.jasuja@intel.com>