### PR TITLE
fix warning in sctputil

### DIFF
--- a/utils/sctp/testlib/sctputil.c
+++ b/utils/sctp/testlib/sctputil.c
@@ -114,7 +114,7 @@ test_print_message(int sk, struct msghdr *msg, size_t msg_len)
 		/* Make sure that everything is printable and that we
 		 * are NUL terminated...
 		 */
-		printf("DATA(%d):  ", msg_len);
+		printf("DATA(%u):  ", msg_len);
 		while ( msg_len > 0 ) {
 			char *text;
 			int len;

--- a/utils/sctp/testlib/sctputil.c
+++ b/utils/sctp/testlib/sctputil.c
@@ -114,7 +114,7 @@ test_print_message(int sk, struct msghdr *msg, size_t msg_len)
 		/* Make sure that everything is printable and that we
 		 * are NUL terminated...
 		 */
-		printf("DATA(%u):  ", msg_len);
+		printf("DATA(%zu):  ", msg_len);
 		while ( msg_len > 0 ) {
 			char *text;
 			int len;


### PR DESCRIPTION
fix warning in sctputil.c:117:3:
    ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ [-Wformat=]
   printf("DATA(%d):  ", msg_len);
   ^