### PR TITLE
Updated wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ compiling and installing the whole testsuite.
 
 Shortcut to running a single test
 ---------------------------------
-
-If you need to execute a single test you actually does not need to compile
-whole LTP, if you want to run a syscall testcase following should work.
+If you need to execute a single test you actually do not need to compile 
+the whole LTP, if you want to run a syscall testcase following should work.
 
 ```
 $ cd testcases/kernel/syscalls/foo


### PR DESCRIPTION
Updated the wording on section "Shortcut to running a single test" as it used the wrong verb (does vs do) and updated some of the words. The idea of the sentence remains but its more readable.

Signed-off-by: Esteban Flores <esflores@microsoft.com>