### PR TITLE
lib/tst_test.c: fix building error for android platform

### DIFF
--- a/include/mk/env_post.mk
+++ b/include/mk/env_post.mk
@@ -44,7 +44,7 @@ endif
 ifeq ($(ANDROID),1)
 # There are many undeclared functions, it's best not to accidentally overlook
 # them.
-CFLAGS				+= -Werror-implicit-function-declaration
+CFLAGS				+= -Werror-implicit-function-declaration -D__ANDROID__
 
 LDFLAGS				+= -L$(top_builddir)/lib/android_libpthread
 LDFLAGS				+= -L$(top_builddir)/lib/android_librt

--- a/lib/tst_test.c
+++ b/lib/tst_test.c
@@ -732,6 +732,7 @@ static int prepare_and_mount_ro_fs(const char *dev,
 
 static void prepare_and_mount_dev_fs(const char *mntpoint)
 {
+#if !defined(__ANDROID__)
 	const char *flags[] = {"nodev", NULL};
 	int mounted_nodev;
 
@@ -742,6 +743,7 @@ static void prepare_and_mount_dev_fs(const char *mntpoint)
 		SAFE_MOUNT(NULL, mntpoint, "tmpfs", 0, NULL);
 		mntpoint_mounted = 1;
 	}
+#endif
 }
 
 static void prepare_device(void)


### PR DESCRIPTION
tst_path_has_mnt_flags.c had been disabled compiling for Android (please check
lib/Makefile), but a reference stills exists in tst_test.c and causes building
error, so we have to disable it.

Signed-off-by: Zhengwang Ruan <ruanzw@xiaopeng.com>