### PR TITLE
include/mk/env_post.mk: enable __ANDROID__ definition for Android build

### DIFF
--- a/include/mk/env_post.mk
+++ b/include/mk/env_post.mk
@@ -44,7 +44,7 @@ endif
 ifeq ($(ANDROID),1)
 # There are many undeclared functions, it's best not to accidentally overlook
 # them.
-CFLAGS				+= -Werror-implicit-function-declaration
+CFLAGS				+= -Werror-implicit-function-declaration -D__ANDROID__
 
 LDFLAGS				+= -L$(top_builddir)/lib/android_libpthread
 LDFLAGS				+= -L$(top_builddir)/lib/android_librt


### PR DESCRIPTION
Enable the __ANDROID__ definition by default for Android build, otherwise we
should manually enable it by configure command.

Signed-off-by: Zhengwang Ruan <ruanzw@xiaopeng.com>