### PR TITLE
chdir04.c: fix out-of-bounds write

### DIFF
--- a/testcases/kernel/syscalls/chdir/chdir04.c
+++ b/testcases/kernel/syscalls/chdir/chdir04.c
@@ -83,14 +83,12 @@ struct test_case_t {
 	     */
 	{
 	noexist_dir, ENOENT},
-#ifndef UCLINUX
 	    /*
 	     * to test whether chdir() is setting EFAULT if the
 	     * directory is an invalid address.
 	     */
 	{
 	(void *)-1, EFAULT}
-#endif
 };
 
 int TST_TOTAL = ARRAY_SIZE(TC);


### PR DESCRIPTION
When UCLINUX is defined, line 156 will write to the TC[2].dname:

>     #ifdef UCLINUX
>         [...]
>         TC[2].dname = bad_addr;
>     #endif

However, TC[2] won't exist as it's only initialized when UCLINUX is not defined and length of TC is implicit. Remove "#ifndef UCLINUX" around initializer for TC[2].