### PR TITLE
madvise08: Fix restore of core_pattern

### DIFF
--- a/testcases/kernel/syscalls/madvise/madvise08.c
+++ b/testcases/kernel/syscalls/madvise/madvise08.c
@@ -41,8 +41,11 @@
 
 static int dfd;
 static void *fmem;
-static char cpattern[CORENAME_MAX_SIZE];
-static int restore_cpattern;
+
+static const char * const save_restore[] = {
+	CORE_PATTERN,
+	NULL,
+};
 
 static void setup(void)
 {
@@ -70,10 +73,6 @@ static void setup(void)
 	if (!(0x1 & filter))
 		tst_brk(TCONF, "Anonymous private memory is not dumpable.");
 
-	SAFE_FILE_SCANF(CORE_PATTERN, "%s[^\n]", cpattern);
-	restore_cpattern = 1;
-	tst_res(TINFO, "System core pattern is '%s'", cpattern);
-
 	SAFE_GETCWD(cwd, sizeof(cwd));
 	snprintf(tmpcpattern, sizeof(tmpcpattern), "%s/dump-%%p", cwd);
 	tst_res(TINFO, "Temporary core pattern is '%s'", tmpcpattern);
@@ -99,9 +98,6 @@ static void setup(void)
 
 static void cleanup(void)
 {
-	if (restore_cpattern)
-		SAFE_FILE_PRINTF(CORE_PATTERN, "%s", cpattern);
-
 	if (fmem)
 		SAFE_MUNMAP(fmem, FMEMSIZE);
 
@@ -221,5 +217,6 @@ static struct tst_test test = {
 	.min_kver = "3.4.0",
 	.needs_tmpdir = 1,
 	.needs_root = 1,
-	.forks_child = 1
+	.forks_child = 1,
+	.save_restore = save_restore
 };


### PR DESCRIPTION
Commit 316d406323f88736ea37909a11b4239051ea95da broke storing and
restoring of core_pattern. This comit changes it to the automatic
save and restore feature of ltp tests