### PR TITLE
Fixes for 64 bit time_t and time() > INT32_MAX

### DIFF
--- a/testcases/network/multicast/mc_commo/mc_send.c
+++ b/testcases/network/multicast/mc_commo/mc_send.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 
 	/* Send datagrams */
 	for (i = 1; i < Num_Loops; i++) {
-		sprintf(buf, "%s %d %d", argv[2], i, (int)time(0));
+		sprintf(buf, "%s %d %lld", argv[2], i, (long long int)time(0));
 		if ((n =
 		     sendto(s, buf, sizeof(buf), 0,
 			    (struct sockaddr *)&mcast_out,

--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/2-1.c
@@ -24,7 +24,8 @@
 int main(void)
 {
 	struct timespec tssleep, tsbefore, tsafter;
-	int sleepuntilsec, flags = 0;
+	time_t sleepuntilsec;
+	int flags = 0;
 
 	if (clock_gettime(CLOCK_REALTIME, &tsbefore) != 0) {
 		perror("clock_gettime() did not return success\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/2-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/2-2.c
@@ -36,7 +36,8 @@ void handler(int signo)
 int main(void)
 {
 	struct timespec tssleep, tsbefore, tsafter;
-	int pid, sleepuntilsec;
+	int pid;
+	time_t sleepuntilsec;
 	struct sigaction act;
 
 	if (clock_gettime(CLOCK_REALTIME, &tsbefore) != 0) {
@@ -95,8 +96,9 @@ int main(void)
 			printf("Test PASSED\n");
 			return PTS_PASS;
 		} else {
-			printf("Slept for too long: %d >= %d\n",
-			       (int)tsafter.tv_sec, sleepuntilsec);
+			printf("Slept for too long: %lld >= %lld\n",
+			       (long long int)tsafter.tv_sec,
+				   (long long int)sleepuntilsec);
 			printf("Test FAILED\n");
 			return PTS_FAIL;
 		}

--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/2-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/2-3.c
@@ -22,7 +22,8 @@
 int main(void)
 {
 	struct timespec tssleep, tsbefore, tsafter;
-	int pid, sleepuntilsec;
+	int pid;
+	time_t sleepuntilsec;
 
 	if (clock_gettime(CLOCK_REALTIME, &tsbefore) != 0) {
 		perror("clock_gettime() did not return success\n");
@@ -68,8 +69,9 @@ int main(void)
 			printf("Test PASSED\n");
 			return PTS_PASS;
 		} else {
-			printf("Slept for too long: %d >= %d\n",
-			       (int)tsafter.tv_sec, sleepuntilsec);
+			printf("Slept for too long: %lld >= %lld\n",
+			       (long long int)tsafter.tv_sec,
+				   (long long int)sleepuntilsec);
 			printf("Test FAILED\n");
 			return PTS_FAIL;
 		}

--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/3-1.c
@@ -25,7 +25,8 @@
 int main(void)
 {
 	struct timespec tssleep, tsbefore, tsafter;
-	int sleepuntilsec, flags = 0;
+	time_t sleepuntilsec;
+	int flags = 0;
 
 	if (clock_gettime(CLOCK_REALTIME, &tsbefore) != 0) {
 		perror("clock_gettime() did not return success\n");

--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_settime/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/clock_settime/8-1.c
@@ -50,7 +50,7 @@ int main(void)
 	if ((pid = fork()) == 0) {
 		/* child here */
 		struct timespec tsend;
-		int expectedsec;
+		time_t expectedsec;
 
 		tssleep.tv_sec = SLEEPSEC;
 		tssleep.tv_nsec = 0;

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_timedreceive/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_timedreceive/5-1.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include "posixtest.h"
+#include "timespec.h"
 
 #define TEST "5-1"
 #define FUNCTION "mq_timedreceive"
@@ -61,7 +62,7 @@ int main(void)
 	if (pid != 0) {
 		/* Parent process */
 		int status;
-		ts.tv_sec = INT32_MAX;
+		ts.tv_sec = TIME_T_MAX;
 		ts.tv_nsec = 0;
 		if (mq_timedreceive(mqdes, msgrv, BUFFER, NULL, &ts) > 0) {
 			wait(&status);

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/5-1.c
@@ -33,6 +33,7 @@
 #include <signal.h>
 #include <errno.h>
 #include "posixtest.h"
+#include "timespec.h"
 
 #define NAMESIZE 50
 #define MSGSTR "0123456789"
@@ -76,7 +77,7 @@ int main(void)
 		struct timespec ts;
 
 		/* set up timeout to be as long as possible */
-		ts.tv_sec = INT32_MAX;
+		ts.tv_sec = TIME_T_MAX;
 		ts.tv_nsec = 0;
 
 		sleep(1);	// give parent time to set up handler

--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/5-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_timedsend/5-2.c
@@ -28,6 +28,7 @@
 #include <signal.h>
 #include <errno.h>
 #include "posixtest.h"
+#include "timespec.h"
 
 #define NAMESIZE 50
 #define MSGSTR "0123456789"
@@ -80,7 +81,7 @@ int main(void)
 		int i;
 		struct timespec ts;
 		/* set up timeout to be as long as possible */
-		ts.tv_sec = INT32_MAX;
+		ts.tv_sec = TIME_T_MAX;
 		ts.tv_nsec = 0;
 
 		sleep(1);	// give parent time to set up handler

--- a/testcases/open_posix_testsuite/include/timespec.h
+++ b/testcases/open_posix_testsuite/include/timespec.h
@@ -13,6 +13,10 @@
 
 #define NSEC_IN_SEC 1000000000
 
+#ifndef TIME_T_MAX
+#	define TIME_T_MAX	(time_t)((1UL << ((sizeof(time_t) << 3) - 1)) - 1)
+#endif
+
 /*
  * Returns difference between two struct timespec values. If difference is
  * greater that 1 sec, 1 sec is returned.


### PR DESCRIPTION
Several tests failed, if the current system time was greater than INT32_MAX.

There are two main reasons:
 1. int was used to do computations with times -> fixed using time_t
 2. INT32_MAX was used as an absolute time to wait "as long as possible". If time() is greater than INT32_MAX, the timeout fired immediately.