### PR TITLE
pitest*: Allow more than 7 cpus

### DIFF
--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-1.c
@@ -54,28 +54,12 @@ pthread_mutex_t mutex;
 volatile int ts_stop = 0;
 volatile double base_time;
 
-struct thread_param {
-	int index;
-	volatile int stop;
-	int sleep_ms;
-	int priority;
-	int policy;
-	const char *name;
-	int cpu;
-	volatile unsigned futex;
-	volatile unsigned should_stall;
-	volatile unsigned progress;
-} tp[] = {
-	{
-	0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0}, {
-	1, 0, 50, 2, SCHED_FIFO, "TP", 0, 0, 0, 0}, {
-	2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}, {
-	3, 0, 0, 3, SCHED_FIFO, "TF", 2, 0, 0, 0}, {
-	4, 0, 0, 3, SCHED_FIFO, "TF", 3, 0, 0, 0}, {
-	5, 0, 0, 3, SCHED_FIFO, "TF", 4, 0, 0, 0}, {
-	6, 0, 0, 3, SCHED_FIFO, "TF", 5, 0, 0, 0}, {
-	7, 0, 0, 3, SCHED_FIFO, "TF", 6, 0, 0, 0}
+struct thread_param tp_template[] = {
+	{0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0},
+	{1, 0, 50, 2, SCHED_FIFO, "TP", 0, 0, 0, 0},
+	{2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}
 };
+struct thread_param *tp;
 
 volatile unsigned do_work_dummy;
 void do_work(unsigned granularity_top, volatile unsigned *progress)
@@ -242,6 +226,8 @@ int main(void)
 	int multiplier = 1;
 	int i;
 	int rc;
+
+	tp = setup_thread_param(tp_template, ARRAY_SIZE(tp_template));
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 6);
 	base_time = seconds_read();

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-2.c
@@ -55,29 +55,13 @@ pthread_mutex_t mutex;
 volatile int ts_stop = 0;
 volatile double base_time;
 
-struct thread_param {
-	int index;
-	volatile int stop;
-	int sleep_ms;
-	int priority;
-	int policy;
-	const char *name;
-	int cpu;
-	volatile unsigned futex;
-	volatile unsigned should_stall;
-	volatile unsigned progress;
-} tp[] = {
-	{
-	0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0}, {
-	1, 0, 500, 2, SCHED_FIFO, "TP1", 0, 0, 0, 0}, {
-	2, 0, 500, 5, SCHED_FIFO, "TP2", 0, 0, 0, 0}, {
-	3, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}, {
-	4, 0, 0, 3, SCHED_FIFO, "TF", 2, 0, 0, 0}, {
-	5, 0, 0, 3, SCHED_FIFO, "TF", 3, 0, 0, 0}, {
-	6, 0, 0, 3, SCHED_FIFO, "TF", 4, 0, 0, 0}, {
-	7, 0, 0, 3, SCHED_FIFO, "TF", 5, 0, 0, 0}, {
-	8, 0, 0, 3, SCHED_FIFO, "TF", 6, 0, 0, 0}
+struct thread_param tp_template[] = {
+	{0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0},
+	{1, 0, 500, 2, SCHED_FIFO, "TP1", 0, 0, 0, 0},
+	{2, 0, 500, 5, SCHED_FIFO, "TP2", 0, 0, 0, 0},
+	{3, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}
 };
+struct thread_param *tp;
 
 volatile unsigned do_work_dummy;
 void do_work(unsigned granularity_top, volatile unsigned *progress)
@@ -268,6 +252,9 @@ int main(void)
 	time_t multiplier = 1;
 	int i;
 	int rc;
+
+
+	tp = setup_thread_param(tp_template, ARRAY_SIZE(tp_template));
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 8);
 	base_time = seconds_read();

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-3.c
@@ -56,29 +56,13 @@ pthread_mutex_t mutex2;
 volatile int ts_stop = 0;
 volatile double base_time;
 
-struct thread_param {
-	int index;
-	volatile int stop;
-	int sleep_ms;
-	int priority;
-	int policy;
-	const char *name;
-	int cpu;
-	volatile unsigned futex;
-	volatile unsigned should_stall;
-	volatile unsigned progress;
-} tp[] = {
-	{
-	0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0}, {
-	1, 0, 500, 2, SCHED_FIFO, "TP1", 0, 0, 0, 0}, {
-	1, 0, 500, 5, SCHED_FIFO, "TP2", 0, 0, 0, 0}, {
-	2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}, {
-	3, 0, 0, 3, SCHED_FIFO, "TF", 2, 0, 0, 0}, {
-	4, 0, 0, 3, SCHED_FIFO, "TF", 3, 0, 0, 0}, {
-	5, 0, 0, 3, SCHED_FIFO, "TF", 4, 0, 0, 0}, {
-	6, 0, 0, 3, SCHED_FIFO, "TF", 5, 0, 0, 0}, {
-	7, 0, 0, 3, SCHED_FIFO, "TF", 6, 0, 0, 0}
+struct thread_param tp_template[] = {
+	{0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0},
+	{1, 0, 500, 2, SCHED_FIFO, "TP1", 0, 0, 0, 0},
+	{1, 0, 500, 5, SCHED_FIFO, "TP2", 0, 0, 0, 0},
+	{2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}
 };
+struct thread_param *tp;
 
 volatile unsigned do_work_dummy;
 void do_work(unsigned granularity_top, volatile unsigned *progress)
@@ -279,6 +263,8 @@ int main(void)
 	time_t multiplier = 1;
 	int i;
 	int rc;
+
+	tp = setup_thread_param(tp_template, ARRAY_SIZE(tp_template));
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 8);
 	base_time = seconds_read();

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-4.c
@@ -57,28 +57,12 @@ pthread_mutex_t mutex2;
 volatile int ts_stop = 0;
 volatile double base_time;
 
-struct thread_param {
-	int index;
-	volatile int stop;
-	int sleep_ms;
-	int priority;
-	int policy;
-	const char *name;
-	int cpu;
-	volatile unsigned futex;
-	volatile unsigned should_stall;
-	volatile unsigned progress;
-} tp[] = {
-	{
-	0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0}, {
-	1, 0, 100, 4, SCHED_FIFO, "TP", 0, 0, 0, 0}, {
-	2, 0, 0, 2, SCHED_FIFO, "TF", 1, 0, 0, 0}, {
-	3, 0, 0, 2, SCHED_FIFO, "TF", 2, 0, 0, 0}, {
-	4, 0, 0, 2, SCHED_FIFO, "TF", 3, 0, 0, 0}, {
-	5, 0, 0, 2, SCHED_FIFO, "TF", 4, 0, 0, 0}, {
-	6, 0, 0, 2, SCHED_FIFO, "TF", 5, 0, 0, 0}, {
-	7, 0, 0, 2, SCHED_FIFO, "TF", 6, 0, 0, 0}
+struct thread_param tp_template[] = {
+	{0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0},
+	{1, 0, 100, 4, SCHED_FIFO, "TP", 0, 0, 0, 0},
+	{2, 0, 0, 2, SCHED_FIFO, "TF", 1, 0, 0, 0}
 };
+struct thread_param *tp;
 
 volatile unsigned do_work_dummy;
 void do_work(unsigned granularity_top, volatile unsigned *progress)
@@ -248,6 +232,8 @@ int main(void)
 	time_t multiplier = 1;
 	int i;
 	int rc;
+
+	tp = setup_thread_param(tp_template, ARRAY_SIZE(tp_template));
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 8);
 	base_time = seconds_read();

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-5.c
@@ -55,28 +55,12 @@ volatile int ts_stop = 0;
 volatile double base_time;
 volatile int unlock_mutex = 0;
 
-struct thread_param {
-	int index;
-	volatile int stop;
-	int sleep_ms;
-	int priority;
-	int policy;
-	const char *name;
-	int cpu;
-	volatile unsigned futex;
-	volatile unsigned should_stall;
-	volatile unsigned progress;
-} tp[] = {
-	{
-	0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0}, {
-	1, 0, 200, 2, SCHED_FIFO, "TP", 0, 0, 0, 0}, {
-	2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}, {
-	3, 0, 0, 3, SCHED_FIFO, "TF", 2, 0, 0, 0}, {
-	4, 0, 0, 3, SCHED_FIFO, "TF", 3, 0, 0, 0}, {
-	5, 0, 0, 3, SCHED_FIFO, "TF", 4, 0, 0, 0}, {
-	6, 0, 0, 3, SCHED_FIFO, "TF", 5, 0, 0, 0}, {
-	7, 0, 0, 3, SCHED_FIFO, "TF", 6, 0, 0, 0}
+struct thread_param tp_template[] = {
+	{0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0},
+	{1, 0, 200, 2, SCHED_FIFO, "TP", 0, 0, 0, 0},
+	{2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}
 };
+struct thread_param *tp;
 
 volatile unsigned do_work_dummy;
 void do_work(unsigned granularity_top, volatile unsigned *progress)
@@ -265,6 +249,8 @@ int main(void)
 	time_t multiplier = 1;
 	int i;
 	int rc;
+
+	tp = setup_thread_param(tp_template, ARRAY_SIZE(tp_template));
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 6);
 	base_time = seconds_read();

--- a/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
+++ b/testcases/open_posix_testsuite/functional/threads/pi_test/pitest-6.c
@@ -53,28 +53,12 @@ pthread_mutex_t mutex;
 volatile int ts_stop = 0;
 volatile double base_time;
 
-struct thread_param {
-	int index;
-	volatile int stop;
-	int sleep_ms;
-	int priority;
-	int policy;
-	const char *name;
-	int cpu;
-	volatile unsigned futex;
-	volatile unsigned should_stall;
-	volatile unsigned progress;
-} tp[] = {
-	{
-	0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0}, {
-	1, 0, 200, 2, SCHED_FIFO, "TP", 0, 0, 0, 0}, {
-	2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}, {
-	3, 0, 0, 3, SCHED_FIFO, "TF", 2, 0, 0, 0}, {
-	4, 0, 0, 3, SCHED_FIFO, "TF", 3, 0, 0, 0}, {
-	5, 0, 0, 3, SCHED_FIFO, "TF", 4, 0, 0, 0}, {
-	6, 0, 0, 3, SCHED_FIFO, "TF", 5, 0, 0, 0}, {
-	7, 0, 0, 3, SCHED_FIFO, "TF", 6, 0, 0, 0}
+struct thread_param tp_template[] = {
+	{0, 0, 0, 1, SCHED_FIFO, "TL", 0, 0, 0, 0},
+	{1, 0, 200, 2, SCHED_FIFO, "TP", 0, 0, 0, 0},
+	{2, 0, 0, 3, SCHED_FIFO, "TF", 1, 0, 0, 0}
 };
+struct thread_param *tp;
 
 volatile unsigned do_work_dummy;
 void do_work(unsigned granularity_top, volatile unsigned *progress)
@@ -241,6 +225,8 @@ int main(void)
 	time_t multiplier = 1;
 	int i;
 	int rc;
+
+	tp = setup_thread_param(tp_template, ARRAY_SIZE(tp_template));
 
 	test_set_priority(pthread_self(), SCHED_FIFO, 6);
 	base_time = seconds_read();


### PR DESCRIPTION
All tests segfaulted, when the system had more than seven cpus,
because of a statically sized thread parameter array.

The thread_param arrays are now created dynamically