### PR TITLE
containers/userns06: Add missing NULL terminator to execve() argument list

### DIFF
--- a/testcases/kernel/containers/userns/userns06.c
+++ b/testcases/kernel/containers/userns/userns06.c
@@ -49,7 +49,7 @@ static int cpid1, parentuid, parentgid;
 static int child_fn1(void)
 {
 	int exit_val = 0;
-	char *const args[] = { "userns06_capcheck", "privileged" };
+	char *const args[] = { "userns06_capcheck", "privileged", NULL };
 
 	TST_SAFE_CHECKPOINT_WAIT(NULL, 0);
 
@@ -69,7 +69,7 @@ static int child_fn2(void)
 {
 	int exit_val = 0;
 	int uid, gid;
-	char *const args[] = { "userns06_capcheck", "unprivileged" };
+	char *const args[] = { "userns06_capcheck", "unprivileged", NULL };
 
 	TST_SAFE_CHECKPOINT_WAIT(NULL, 1);
 


### PR DESCRIPTION
Hi,
in the containers/userns06 test, the command line arguments are passed to execve() without a teminating NULL pointer. This somehow passes on x86_64 (WTF?) but crashes on PPC64 (as it should). Here's a patch to pass a well-formed argument list.