### PR TITLE
cve-2017-17052: Reset exit condition in each test run

### DIFF
--- a/testcases/cve/cve-2017-17052.c
+++ b/testcases/cve/cve-2017-17052.c
@@ -90,9 +90,11 @@ static void do_test_fork(void)
 static void run(void)
 {
 	pid_t pid;
+	int status;
 	volatile int run = 0;
 
 	while (run < RUNS) {
+		*do_exit = 0;
 		pid = SAFE_FORK();
 
 		if (pid == 0) {
@@ -101,7 +103,14 @@ static void run(void)
 			usleep(EXEC_USEC);
 			*do_exit = 1;
 		}
-		tst_res(TINFO, "run %d passed", run);
+
+		SAFE_WAIT(&status);
+		if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+			tst_res(TINFO, "run %d passed", run);
+		} else {
+			tst_res(TFAIL, "child %s", tst_strstatus(status));
+		}
+
 		run++;
 	}
 


### PR DESCRIPTION
The exit condition is set in each test run, but it was only resetted
once during setup. Because of that the follow up runs were exiting
prematurely.

We now reset the exit condition before each run and also wait for the
child process to exit before continuing.