### PR TITLE
openposix/aio_cancel/5-1: Retry test if it does not succeed

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/aio_cancel/5-1.c
@@ -13,7 +13,7 @@
  *
  * method:
  *
- *	queue a some aio_write() to a file descriptor
+ *	queue some aio_write() to a file descriptor
  *	cancel all operations for this file descriptor
  *	for all operations not canceled at end of operations
  *	verify that values in aiocb is the good ones
@@ -36,23 +36,26 @@
 
 #include "posixtest.h"
 
+#define NO_FINISHED -2
+#define NO_CANCELED -3
+
 #define TNAME "aio_cancel/5-1.c"
 
 #define BUF_NB		128
 #define BUF_SIZE	1024
+#define MAX_RETRIES 50
 
-int main(void)
+static char aio_buffer[BUF_NB][BUF_SIZE];
+static struct aiocb aiocb[BUF_NB];
+
+int do_test(void)
 {
 	char tmpfname[256];
 	int fd;
-	struct aiocb *aiocb[BUF_NB];
-	char *buf[BUF_NB];
 	int i;
 	int in_progress;
-	static int check_one;
-
-	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
-		return PTS_UNSUPPORTED;
+	int check_one_done;
+	int check_one_canceled;
 
 	snprintf(tmpfname, sizeof(tmpfname), "/tmp/pts_aio_cancel_5_1_%d",
 		 getpid());
@@ -66,27 +69,15 @@ int main(void)
 	unlink(tmpfname);
 
 	/* create AIO req */
-
 	for (i = 0; i < BUF_NB; i++) {
-		aiocb[i] = calloc(1, sizeof(struct aiocb));
-		if (aiocb[i] == NULL) {
-			printf(TNAME " Error at malloc(): %s\n",
-			       strerror(errno));
-			return PTS_UNRESOLVED;
-		}
-		buf[i] = malloc(BUF_SIZE);
-		if (buf[i] == NULL) {
-			printf(TNAME " Error at malloc(): %s\n",
-			       strerror(errno));
-			return PTS_UNRESOLVED;
-		}
-		aiocb[i]->aio_fildes = fd;
-		aiocb[i]->aio_buf = buf[i];
-		aiocb[i]->aio_nbytes = BUF_SIZE;
-		aiocb[i]->aio_offset = 0;
-		aiocb[i]->aio_sigevent.sigev_notify = SIGEV_NONE;
+		memset(&aiocb[i], 0, sizeof(aiocb[i]));
+		aiocb[i].aio_fildes = fd;
+		aiocb[i].aio_buf = aio_buffer[i];
+		aiocb[i].aio_nbytes = BUF_SIZE;
+		aiocb[i].aio_offset = 0;
+		aiocb[i].aio_sigevent.sigev_notify = SIGEV_NONE;
 
-		if (aio_write(aiocb[i]) == -1) {
+		if (aio_write(&aiocb[i]) == -1) {
 			printf(TNAME " loop %d: Error at aio_write(): %s\n",
 			       i, strerror(errno));
 			return PTS_FAIL;
@@ -94,9 +85,7 @@ int main(void)
 	}
 
 	/* try to cancel all
-	 * we hope to have enough time to cancel at least one
-	 */
-
+	 * we hope to have enough time to cancel at least one */
 	if (aio_cancel(fd, NULL) == -1) {
 		printf(TNAME " Error at aio_cancel(): %s\n", strerror(errno));
 		return PTS_FAIL;
@@ -104,32 +93,32 @@ int main(void)
 
 	close(fd);
 
-	check_one = 0;
+	check_one_done = 0;
+	check_one_canceled = 0;
 	do {
 		in_progress = 0;
 		for (i = 0; i < BUF_NB; i++) {
 			int ret;
 
-			ret = (aio_error(aiocb[i]));
+			ret = (aio_error(&aiocb[i]));
 
 			if (ret == -1) {
-				printf(TNAME " Error at aio_error(): %s\n",
-				       strerror(errno));
+				printf(TNAME " Error at aio_error(): %s\n", strerror(errno));
 				return PTS_FAIL;
+			} else if (ret == ECANCELED) {
+				check_one_canceled = 1;
 			} else if ((ret == EINPROGRESS) || (ret == 0)) {
 				if (ret == EINPROGRESS)
 					in_progress = 1;
 
-				check_one = 1;
+				check_one_done = 1;
 
 				/* check iocb is not modified */
-
-				if ((aiocb[i]->aio_fildes != fd) ||
-				    (aiocb[i]->aio_buf != buf[i]) ||
-				    (aiocb[i]->aio_nbytes != BUF_SIZE) ||
-				    (aiocb[i]->aio_offset != 0) ||
-				    (aiocb[i]->aio_sigevent.sigev_notify !=
-				     SIGEV_NONE)) {
+				if ((aiocb[i].aio_fildes != fd) ||
+				    (aiocb[i].aio_buf != aio_buffer[i]) ||
+				    (aiocb[i].aio_nbytes != BUF_SIZE) ||
+				    (aiocb[i].aio_offset != 0) ||
+				    (aiocb[i].aio_sigevent.sigev_notify != SIGEV_NONE)) {
 					printf(TNAME " aiocbp modified\n");
 					return PTS_FAIL;
 				}
@@ -137,8 +126,39 @@ int main(void)
 		}
 	} while (in_progress);
 
-	if (!check_one)
-		return PTS_UNRESOLVED;
+	if (!check_one_done) {
+		return NO_FINISHED;
+	} else if (!check_one_canceled) {
+		return NO_CANCELED;
+	}
 
 	return PTS_PASS;
+}
+
+int main(void)
+{
+	int num_retries;
+
+	if (sysconf(_SC_ASYNCHRONOUS_IO) < 200112L)
+		return PTS_UNSUPPORTED;
+
+	for (num_retries = 0; num_retries < MAX_RETRIES; ++num_retries) {
+		int ret = do_test();
+
+		if (ret == NO_FINISHED || ret == NO_CANCELED) {
+			printf(TNAME " INFO retry (no requests %s)\n", 
+				   ret == NO_FINISHED ? "finished" : " canceled");
+			continue;
+		}
+
+		if (ret == PTS_PASS)
+			printf(TNAME " PASS (%d retries)\n", num_retries);
+
+		return ret;
+	}
+
+	printf(TNAME " UNRESOLVED: In %d retries not one request finished and while one was canceled\n",
+		   MAX_RETRIES);
+
+	return PTS_UNRESOLVED;
 }


### PR DESCRIPTION
The test starts some aio request and cancels them. It then expects,
that at least one request was not canceled and succeeded. Sometimes
no test succeeds and the test failed with PTS_UNRESOLVED.
Now the test is repeated up to 50 times, to allow it to succeed most
of the time. Also a check was added, that at least one request was
canceled by the call to aio_cancel, to ensure we test the correct thing.