### PR TITLE
lib: Fix safe_mount() when mounting NTFS as r/w on kernels with NTFS

### DIFF
--- a/lib/safe_macros.c
+++ b/lib/safe_macros.c
@@ -726,9 +726,15 @@ int safe_mount(const char *file, const int lineno, void (*cleanup_fn)(void),
 {
 	int rval;
 
-	rval = mount(source, target, filesystemtype, mountflags, data);
-	if (!rval)
-		return 0;
+	/*
+	 * Don't try using the kernel's NTFS driver when mounting NTFS, since
+	 * the kernel's NTFS driver doesn't have proper write support.
+	 */
+	if (strcmp(filesystemtype, "ntfs")) {
+		rval = mount(source, target, filesystemtype, mountflags, data);
+		if (!rval)
+			return 0;
+	}
 
 	/*
 	 * The FUSE filesystem executes mount.fuse helper, which tries to


### PR DESCRIPTION
The kernel's NTFS driver (CONFIG_NTFS_FS) can only be used for reading
NTFS images, not writing to them since it lacks stable r/w support. As a
result, when NTFS is mounted using the kernel's driver for tests that
require r/w support, the tests fail to write to the mounted NTFS images.
The only way to achieve proper NTFS r/w support on Linux is to use FUSE,
so mounting with FUSE should be the only option when NTFS needs to be
mounted as r/w.

Fix this by never trying to mount NTFS using the kernel's driver when
the mount is r/w.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>