### PR TITLE
controllers/cpuset: improve the node number calculation for N_NODES

### DIFF
--- a/testcases/kernel/controllers/cpuset/cpuset_funcs.sh
+++ b/testcases/kernel/controllers/cpuset/cpuset_funcs.sh
@@ -28,12 +28,19 @@
 
 NR_CPUS=`tst_ncpus`
 if [ -f "/sys/devices/system/node/has_high_memory" ]; then
-	N_NODES="`cat /sys/devices/system/node/has_high_memory`"
+	N_NODES="`cat /sys/devices/system/node/has_high_memory | tr ',' ' '`"
 else
-	N_NODES="`cat /sys/devices/system/node/has_normal_memory`"
+	N_NODES="`cat /sys/devices/system/node/has_normal_memory | tr ',' ' '`"
 fi
-N_NODES=${N_NODES#*-*}
-N_NODES=$(($N_NODES + 1))
+count=0
+for item in $N_NODES; do
+	delta=1
+	if [ "${item#*-*}" != "$item" ]; then
+		delta=$((${item#*-*} - ${item%*-*} + 1))
+	fi
+	count=$((count + $delta))
+done
+N_NODES=$count
 
 CPUSET="/dev/cpuset"
 CPUSET_TMP="/tmp/cpuset_tmp"


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/1836188

Issue spotted on a Power9 system with Ubuntu Eoan installed, the
N_NODES obtained from the file contains only "0,8":

    $ cat /sys/devices/system/node/has_normal_memory
    0,8

This will cause the N_NODES calculation in cpuset_funcs.sh failed with:

    cpuset_funcs.sh: arithmetic expression: expecting EOF: "0,8 + 1"

As it's expecting the number of a range (dash separated), but not comma
separated nodes. And this is causing failures to any test that's calling
this cpuset_funcs.sh:
    * cpuset_base_ops
    * cpuset_exclusive
    * cpuset_hierarchy
    * cpuset_hotplug cpuset_inherit
    * cpuset_load_balance
    * cpuset_memory cpuset_memory_pressure
    * cpuset_memory_spread
    * cpuset_sched_domains
    * cpuset_syscall

Improve the node number calculation by replacing the comma with space,
iterate through them to count the number of nodes. If we ever encounter
a range format like "3-6", use shell substitution to get these two
numbers and with their difference plus 1 to get the number of nodes in
this range.

Let's assume some extreme examples, if N_NODES is:
    0,2,4-6,8
In this case the improved algorithm will give you 6.
And if N_NODES is:
   0,2,4-6,8,11-15
This will get you 11.

Patch tested with the affected Power9 node, this fix works as expected,
all the cpuset_* jobs will be executed instead of failing with this arithmetic
expression error.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>