### PR TITLE
scenario_groups/default: remove the fs_ext4 test

### DIFF
--- a/scenario_groups/default
+++ b/scenario_groups/default
@@ -21,7 +21,6 @@ power_management_tests
 hugetlb
 commands
 hyperthreading
-fs_ext4
 can
 cpuhotplug
 net.ipv6_lib


### PR DESCRIPTION
The fs_ext4 test has been removed in commit 29f51a85 (Delete New ext4
features tests and ffsb tool)

Let's remove it from the default scenario group.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>