### PR TITLE
hugetlb: adjust SAFE_FILE_SCANF() before save_nr_hugepages()

### DIFF
--- a/testcases/kernel/mem/hugetlb/hugeshmat/hugeshmat04.c
+++ b/testcases/kernel/mem/hugetlb/hugeshmat/hugeshmat04.c
@@ -38,7 +38,7 @@
 static long huge_free;
 static long huge_free2;
 static long hugepages;
-static long orig_shmmax, new_shmmax;
+static long orig_shmmax = -1, new_shmmax;
 
 static void shared_hugepage(void);
 
@@ -106,7 +106,8 @@ static void setup(void)
 static void cleanup(void)
 {
 	restore_nr_hugepages();
-	SAFE_FILE_PRINTF(PATH_SHMMAX, "%ld", orig_shmmax);
+	if(orig_shmmax != -1)
+		SAFE_FILE_PRINTF(PATH_SHMMAX, "%ld", orig_shmmax);
 }
 
 static struct tst_test test = {

--- a/testcases/kernel/mem/hugetlb/hugeshmat/hugeshmat04.c
+++ b/testcases/kernel/mem/hugetlb/hugeshmat/hugeshmat04.c
@@ -85,9 +85,9 @@ static void setup(void)
 {
 	long mem_total, hpage_size, orig_hugepages;
 
+	SAFE_FILE_SCANF(PATH_SHMMAX, "%ld", &orig_shmmax);
 	orig_hugepages = save_nr_hugepages();
 	mem_total = SAFE_READ_MEMINFO("MemTotal:");
-	SAFE_FILE_SCANF(PATH_SHMMAX, "%ld", &orig_shmmax);
 	SAFE_FILE_PRINTF(PATH_SHMMAX, "%ld", (long)SIZE);
 	SAFE_FILE_SCANF(PATH_SHMMAX, "%ld", &new_shmmax);
 

--- a/testcases/kernel/mem/hugetlb/hugeshmget/hugeshmget03.c
+++ b/testcases/kernel/mem/hugetlb/hugeshmget/hugeshmget03.c
@@ -39,7 +39,7 @@ static int num_shms;
 static int shm_id_arr[MAXIDS];
 
 static long hugepages = 128;
-static long orig_shmmni;
+static long orig_shmmni = -1;
 static struct tst_option options[] = {
 	{"s:", &nr_opt, "-s   num  Set the number of the been allocated hugepages"},
 	{NULL, NULL, NULL}
@@ -104,7 +104,8 @@ static void cleanup(void)
 	for (i = 0; i < num_shms; i++)
 		rm_shm(shm_id_arr[i]);
 
-	FILE_PRINTF(PATH_SHMMNI, "%ld", orig_shmmni);
+	if(orig_shmmni != -1)
+		FILE_PRINTF(PATH_SHMMNI, "%ld", orig_shmmni);
 	restore_nr_hugepages();
 }
 

--- a/testcases/kernel/mem/hugetlb/hugeshmget/hugeshmget03.c
+++ b/testcases/kernel/mem/hugetlb/hugeshmget/hugeshmget03.c
@@ -64,11 +64,10 @@ static void setup(void)
 {
 	long hpage_size;
 
+	SAFE_FILE_SCANF(PATH_SHMMNI, "%ld", &orig_shmmni);
 	save_nr_hugepages();
 	if (nr_opt)
 		hugepages = SAFE_STRTOL(nr_opt, 0, LONG_MAX);
-
-	SAFE_FILE_SCANF(PATH_SHMMNI, "%ld", &orig_shmmni);
 
 	limit_hugepages(&hugepages);
 	set_sys_tune("nr_hugepages", hugepages, 1);


### PR DESCRIPTION
In save_nr_hugepages() it will do check_hugepage(). If there
is no Huge page support in system, it will do cleanup() and write
wrong orig_shmmni and orig_shmmax value back to file.

Hence, we should adjust SAFE_FILE_SCANF() before save_nr_hugepages()
to ensure orig_shmmni and orig_shmmax value is correct.

Signed-off-by: Eric Lin <tesheng@andestech.com>