### PR TITLE
Fix static linking with musl-fts

### DIFF
--- a/testcases/kernel/controllers/cpuset/Makefile.inc
+++ b/testcases/kernel/controllers/cpuset/Makefile.inc
@@ -41,7 +41,7 @@ MAKE_DEPS		:= $(LIBCONTROLLERS) $(LIBCPUSET)
 
 LDFLAGS			+= -L$(abs_builddir)/$(LIBCPUSET_DIR) -L$(abs_builddir)/$(LIBCONTROLLERS_DIR)
 
-LDLIBS			+= -lcpu_set -lcontrollers -lltp
+LDLIBS			:= -lcpu_set -lcontrollers -lltp $(LDLIBS)
 
 INSTALL_TARGETS		?= *.sh
 

--- a/testcases/kernel/controllers/cpuset/cpuset_lib/Makefile
+++ b/testcases/kernel/controllers/cpuset/cpuset_lib/Makefile
@@ -25,7 +25,7 @@ top_srcdir 		?= ../../../../..
 
 include $(top_srcdir)/include/mk/testcases.mk
 
-LDLIBS			+= -lm -lcontrollers -lltp
+LDLIBS			:= -lm -lcontrollers -lltp $(LDLIBS)
 
 LIB			:= libcpu_set.a
 


### PR DESCRIPTION
Don't append libraries to LDLIBS but prepend them in cpuset_lib/Makefile
and cpuset/Makefile.inc to allow the user to provide its FTS library
such as -lfts for musl/uclibc through LDLIBS

This will fix static build of ltp with musl-fts on uclibc

Fixes:
 - http://autobuild.buildroot.org/results/9155326e1ff7c2bb2218122c453872c2fc76f65e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>