### PR TITLE
use SOL_SOCKET instead of fixed value when call setsockopt func, this…

### DIFF
--- a/testcases/cve/cve-2017-16939.c
+++ b/testcases/cve/cve-2017-16939.c
@@ -66,7 +66,7 @@ static void run(void)
 {
 	int var = 0x100;
 
-	SAFE_SETSOCKOPT(fd, 1, SO_RCVBUF, &var, sizeof(int));
+	SAFE_SETSOCKOPT(fd, SOL_SOCKET, SO_RCVBUF, &var, sizeof(int));
 	SAFE_SENDTO(1, fd, (void *) &p->msg, p->msg.nlmsg_len, 0,
 		    (struct sockaddr *) &addr,
 		    sizeof(struct sockaddr_nl));


### PR DESCRIPTION
MIPS platform failed on cve-2017-16939 test, got below result:
### safe_net.c:186: BROK: cve-2017-16939.c:69: setsockopt(6, 1, 4098, 0xfffbaff810, 4) failed: ENOPROTOOPT (99)

Commonly, SOL_SOCKET value is 1, but on MIPS architecture SOL_SOCKET is 0xffff

So i use SOL_SOCKET instead of fixed value when use setsockopt func, this can solve MIPS architecture failed issue.


Signed-off-by:  Zhenglong Cai  caizhenglong_cm@deepin.com