### PR TITLE
containers: typo correction and config update

### DIFF
--- a/testcases/kernel/containers/README
+++ b/testcases/kernel/containers/README
@@ -20,8 +20,9 @@
 
 CONTAINER TESTS AUTOMATION SUITE
 ----------------------------
-The tests requires the Kernel to  be compiled with the following config's
+The tests requires the Kernel to be compiled with the following configs
 
+CONFIG_DUMMY=y(or =m)
 CONFIG_NAMESPACES=y
 CONFIG_UTS_NS=y
 CONFIG_IPC_NS=y


### PR DESCRIPTION
The containers/netns/netns_sysfs.sh will need the dummy net driver
controlled by the CONFIG_DUMMY.

Add this to the README and do some typo corrections.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>