### PR TITLE
Use SDKTARGETSYSROOT when available

### DIFF
--- a/m4/ltp-tirpc.m4
+++ b/m4/ltp-tirpc.m4
@@ -6,7 +6,11 @@ AC_DEFUN([LTP_CHECK_TIRPC],[
 	TIRPC_LIBS=""
 
 	AC_CHECK_HEADERS([tirpc/netconfig.h netconfig.h], [
-		TIRPC_CPPFLAGS="-I${SYSROOT}/usr/include/tirpc"
+		if [[ -n $SDKTARGETSYSROOT ]]; then
+			TIRPC_CPPFLAGS="-I${SDKTARGETSYSROOT}/usr/include/tirpc"
+		else
+			TIRPC_CPPFLAGS="-I${SYSROOT}/usr/include/tirpc"
+		fi
 		AC_DEFINE(HAVE_LIBTIRPC, 1, [Define to 1 if you have libtirpc headers installed])
 		AC_CHECK_LIB(tirpc, rpcb_set, [TIRPC_LIBS="-ltirpc"])])
 

--- a/m4/ltp-tirpc.m4
+++ b/m4/ltp-tirpc.m4
@@ -6,7 +6,7 @@ AC_DEFUN([LTP_CHECK_TIRPC],[
 	TIRPC_LIBS=""
 
 	AC_CHECK_HEADERS([tirpc/netconfig.h netconfig.h], [
-		if [[ -n $SDKTARGETSYSROOT ]]; then
+		if test -n "$SDKTARGETSYSROOT"; then
 			TIRPC_CPPFLAGS="-I${SDKTARGETSYSROOT}/usr/include/tirpc"
 		else
 			TIRPC_CPPFLAGS="-I${SYSROOT}/usr/include/tirpc"


### PR DESCRIPTION
$SYSROOT is assumed to be available in m4/ltp-tirpc.m4 but will not be set when using certain SDKs, for example SDKs built in YOCTO as they use $SDKTARGETSYSROOT
My background knowledge is limited so this might not be a fix you are interested in, but we found it useful.

Signed-off-by: Gustav Krantz <gustav.krantz@microsoft.com>