### PR TITLE
DEFINE_PCI_DEVICE_TABLE has been removed since 4.8

### DIFF
--- a/testcases/kernel/device-drivers/pci/tpci_kernel/ltp_tpci.c
+++ b/testcases/kernel/device-drivers/pci/tpci_kernel/ltp_tpci.c
@@ -61,7 +61,7 @@ MODULE_LICENSE("GPL");
 #define TFAIL	1
 #define TSKIP	32
 
-static DEFINE_PCI_DEVICE_TABLE(ltp_pci_tbl) = {
+static const struct pci_device_id ltp_pci_tbl[] = {
 	{ PCI_DEVICE(PCI_ANY_ID, PCI_ANY_ID) },
 	{ 0, }
 };


### PR DESCRIPTION
linux 4.8 has removed DEFINE_PCI_DEVICE_TABLE since 4.8