### PR TITLE
mem/vma: fix vsyscall permission parsion for newer kernels

### DIFF
--- a/testcases/kernel/mem/vma/vma05.sh
+++ b/testcases/kernel/mem/vma/vma05.sh
@@ -44,7 +44,7 @@ vma_report_check()
 {
 	if [ $(uname -m) = "x86_64" ]; then
 		if LINE=$(grep "vsyscall" /proc/self/maps); then
-			RIGHT="ffffffffff600000-ffffffffff601000[[:space:]]r-xp"
+			RIGHT="ffffffffff600000-ffffffffff601000[[:space:]][r-]-xp"
 			if echo "$LINE" | grep -q "$RIGHT"; then
 				tst_res TPASS "[vsyscall] reported correctly"
 			else


### PR DESCRIPTION
In newer kernels, the permission for vsyscall has been further
restricted to be non-readable and execute-only to gain the security
with commit bd49e16e (x86/vsyscall: Add a new vsyscall=xonly mode).

In this case the pattern in /proc/self/maps will become:
  ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0 [vsyscall]

And thus failed with the expected pattern parsing test:
  vma05 1 TFAIL: [vsyscall] reporting wrong

Fix this by changing the permission pattern to look for [r-]-xp,
ensure it can match both cases.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>