### PR TITLE
Fix for missing CAP_SYS_TIME in ltp - ./include/lapi/capability.h

### DIFF
--- a/include/lapi/capability.h
+++ b/include/lapi/capability.h
@@ -24,12 +24,12 @@
 # define CAP_NET_RAW          13
 #endif
 
-#ifndef CAP_SYS_TIME
-#define CAP_SYS_TIME          25
-#endif
-
 #ifndef CAP_SYS_ADMIN
 # define CAP_SYS_ADMIN        21
+#endif
+
+#ifndef CAP_SYS_TIME
+#define CAP_SYS_TIME          25
 #endif
 
 #ifndef CAP_AUDIT_READ

--- a/include/lapi/capability.h
+++ b/include/lapi/capability.h
@@ -24,6 +24,10 @@
 # define CAP_NET_RAW          13
 #endif
 
+#ifndef CAP_SYS_TIME
+#define CAP_SYS_TIME          25
+#endif
+
 #ifndef CAP_SYS_ADMIN
 # define CAP_SYS_ADMIN        21
 #endif


### PR DESCRIPTION
The missing CAP_SYS_TIME in ltp/include/lapi/capability.h was causing build failure during the compiling stage of settimeofday02.c  Mentioned below are log details of the failed and successful build  with the fix.  

make
[..downsized output.. ]
..
gcc -g -O2 -g -O2 -fno-strict-aliasing -pipe -Wall -W -Wold-style-definition -D_FORTIFY_SOURCE=2
-I../../../../include -I../../../../include -I../../../../include/old/   -L../../../../lib  settimeofday02.c   -lltp -o settimeofday02
In file included from settimeofday02.c:11:
settimeofday02.c:67:25: error: ‘CAP_SYS_TIME’ undeclared here (not in a function); did you mean ‘CAP_SYS_ADMIN’?
   TST_CAP(TST_CAP_DROP, CAP_SYS_TIME),
                         ^~~~~~~~~~~~
../../../../include/tst_capability.h:21:46: note: in definition of macro ‘TST_CAP’
 #define TST_CAP(action, capability) {action, capability, #capability}
                                              ^~~~~~~~~~
settimeofday02.c:70:1: warning: missing initializer for field ‘test_all’ of ‘struct tst_test’ [-Wmissing-field-initializers]
 };
 ^
In file included from settimeofday02.c:12:
../../../../include/tst_test.h:202:9: note: ‘test_all’ declared here
  void (*test_all)(void);
         ^~~~~~~~
make[4]: *** [<builtin>: settimeofday02] Error 1
make[4]: Leaving directory '/home/ronald/ltp/testcases/kernel/syscalls/settimeofday'
make[3]: *** [../../../include/mk/generic_trunk_target.inc:93: all] Error 2
make[3]: Leaving directory '/home/ronald/ltp/testcases/kernel/syscalls'
make[2]: *** [../../include/mk/generic_trunk_target.inc:93: all] Error 2
make[2]: Leaving directory '/home/ronald/ltp/testcases/kernel'
make[1]: *** [../include/mk/generic_trunk_target.inc:93: all] Error 2
make[1]: Leaving directory '/home/ronald/ltp/testcases'
make: *** [Makefile:108: testcases-all] Error 2
root@vm37-224 ltp


After applying the fix build succeeded as shown below

< … >
make[4]: Leaving directory '/home/ronald/ltp/testcases/kernel/syscalls/wait4'
make[4]: Entering directory '/home/ronald/ltp/testcases/kernel/syscalls/settimeofday'
install -m 00775 "/home/ronald/ltp/testcases/kernel/syscalls/settimeofday/settimeofday01" "/opt/ltp/testcases/bin/settimeofday01"
install -m 00775 "/home/ronald/ltp/testcases/kernel/syscalls/settimeofday/settimeofday02" "/opt/ltp/testcases/bin/settimeofday02"
make[4]: Leaving directory '/home/ronald/ltp/testcases/kernel/syscalls/settimeofday'
make[4]: Entering directory '/home/ronald/ltp/testcases/kernel/syscalls/sched_get_priority_min'
install -m 00775 "/home/ronald/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min01" "/opt/ltp/testcases/bin/sched_get_priority_min01"
install -m 00775 "/home/ronald/ltp/testcases/kernel/syscalls/sched_get_priority_min/sched_get_priority_min02" "/opt/ltp/testcases/bin/sched_get_priority_min02"
make[4]: Leaving directory '/home/ronald/ltp/testcases/kernel/syscalls/sched_get_priority_min'
 < .. >

Signed-off-by: Ronald Monthero <rmonther@redhat.com>