### PR TITLE
Fix issue when running fcntl31 and fcntl31_64 over SSH as session leader

### DIFF
--- a/testcases/kernel/syscalls/fcntl/fcntl31.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl31.c
@@ -116,9 +116,12 @@ static void setup(void)
 
 	pid = getpid();
 
-	ret = setpgrp();
-	if (ret < 0)
-		tst_brkm(TBROK | TERRNO, cleanup, "setpgrp() failed");
+	/* Changing process group ID is forbidden when PID == SID i.e. we are session leader */
+	if (pid != getsid(0)) {
+		ret = setpgrp();
+		if (ret < 0)
+			tst_brkm(TBROK | TERRNO, cleanup, "setpgrp() failed");
+	}
 	pgrp_pid = getpgid(0);
 	if (pgrp_pid < 0)
 		tst_brkm(TBROK | TERRNO, cleanup, "getpgid() failed");


### PR DESCRIPTION
If you run the test like this:
ssh localhost path/to/fcntl31

It will fail like this:
TBROK  :  fcntl31.c:121: setpgrp() failed: errno=EPERM(1): Operation not permitted

As man page for setpgrp says, it is indeed not permitted to change process group ID
when you are session leader (PID == SID).