### PR TITLE
lib/tst_cgroup.c: run tst_cgroup_del_path() only if tst_cgroup_paths is not NULL

### DIFF
--- a/lib/tst_cgroup.c
+++ b/lib/tst_cgroup.c
@@ -233,7 +233,7 @@ static void tst_cgroup_del_path(const char *cgroup_dir)
 {
 	struct tst_cgroup_path *a, *b;
 
-	if (tst_cgroup_paths)
+	if (!tst_cgroup_paths)
 		return;
 
 	a = b = tst_cgroup_paths;


### PR DESCRIPTION
This first thing in tst_cgroup_del_path() is to check the
tst_cgroup_paths variable, however this if statment is missing an
exclamation mark for checking if it is NULL. So it will only get
processed when it's NULL and thus causing error.

In this case test mm/ksm02, mm/ksm03, mm/ksm04 will fail on a kernel
that does not have CONFIG_KSM enabled (like the Ubuntu KVM kernel),
instead of being skipped.

They will fail with the following error messages when doing the
tst_cgroup_del_path() in the cleanup() process of the test:

 tag=ksm02 stime=1593792700 dur=2 exit=exited stat=34 core=no cu=0 cs=0
 startup='Fri Jul 3 16:11:40 2020'
 tst_sys_conf.c:58: INFO: Path not found: '/sys/kernel/mm/ksm/max_page_sharing'
 tst_test.c:1245: INFO: Timeout per run is 0h 05m 00s
 ksm02.c:96: CONF: KSM configuration is not enabled
 tst_device.c:418: INFO: No device is mounted at /tmp/cgroup_cst
 tst_test.c:1292: BROK: Test killed by SIGSEGV!
 Summary:
 passed 0
 failed 0
 skipped 1
 warnings 0

https://bugs.launchpad.net/bugs/1886409

Fixes: 3b716981bd54 ("lib: add new cgroup test API")
Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>