### PR TITLE
cpuset_hotplug_test.sh: Fix a race condition

### DIFF
--- a/testcases/kernel/controllers/cpuset/cpuset_hotplug_test/cpuset_hotplug_test.sh
+++ b/testcases/kernel/controllers/cpuset/cpuset_hotplug_test/cpuset_hotplug_test.sh
@@ -86,6 +86,11 @@ root_cpu_hotplug_test()
 		return 1
 	fi
 
+	# cpuset hotplug is asynchronous operation, we could end up reading a
+	# stale value here. sleep is aweful, but we can't do better.
+	# See https://github.com/linux-test-project/ltp/issues/693
+	sleep 1
+
 	root_cpus="`cat $CPUSET/cpuset.cpus`"
 
 	task_cpus="`cat /proc/$tst_pid/status | grep Cpus_allowed_list`"
@@ -154,6 +159,11 @@ general_cpu_hotplug_test()
 		/bin/kill -s SIGKILL $tst_pid
 		return 1
 	fi
+
+	# cpuset hotplug is asynchronous operation, we could end up reading a
+	# stale value here. sleep is aweful, but we can't do better.
+	# See https://github.com/linux-test-project/ltp/issues/693
+	sleep 1
 
 	cpus="`cat $path/cpuset.cpus`"
 


### PR DESCRIPTION
Cpuset performs hotplug updates asynchronously in the kernel. This would
lead to a race window where userspace could read a stale value before
the asynchronous update is performed (via a delayed work).

An attempt to fix the issue in the kernel failed.

https://lore.kernel.org/lkml/20200211141554.24181-1-qais.yousef@arm.com/T/#u

There was a patch to make the update synchronous, but it hit a wall and
was dropped

https://lore.kernel.org/lkml/F0388D99-84D7-453B-9B6B-EEFF0E7BE4CC@lca.pw/

The sleep is not ideal, but the maintainer has pushed back for a fix in
the kernel so far.

Fixes #693.
Signed-off-by: Qais Yousef <qais.yousef@arm.com>