### PR TITLE
connectors/pec/README: Fix spelling error

### DIFF
--- a/testcases/kernel/connectors/pec/README
+++ b/testcases/kernel/connectors/pec/README
@@ -31,7 +31,7 @@ This script runs all the 5 testcases.
 
 pec_listener.c
 ------------------
-This program is used to ilsten to process events received through the kernel
+This program is used to listen to process events received through the kernel
 connector and print them.
 
 Makefile


### PR DESCRIPTION
'ilsten' to 'listen'

Signed-off-by: Tree Davies <tdavies@darkphysics.net>