### PR TITLE
Fix typo in tst_test.c

### DIFF
--- a/lib/tst_test.c
+++ b/lib/tst_test.c
@@ -1378,7 +1378,7 @@ void tst_flush(void)
 	if (rval != 0)
 		tst_brk(TBROK | TERRNO, "fflush(stderr) failed");
 
-	rval = fflush(stderr);
+	rval = fflush(stdout);
 	if (rval != 0)
 		tst_brk(TBROK | TERRNO, "fflush(stdout) failed");
 


### PR DESCRIPTION
stderr was flushed in previous lines
and so flushing stdout

resolves: #716 

Signed-off-by: Vishwajith K <vishuvikas1996@yahoo.com>