### PR TITLE
fanotify.h: fix build with uclibc

### DIFF
--- a/testcases/kernel/syscalls/fanotify/fanotify.h
+++ b/testcases/kernel/syscalls/fanotify/fanotify.h
@@ -139,6 +139,11 @@ struct fanotify_event_info_fid {
 #endif /* HAVE_STRUCT_FANOTIFY_EVENT_INFO_FID_FSID___VAL */
 
 #ifdef HAVE_NAME_TO_HANDLE_AT
+
+#ifndef MAX_HANDLE_SZ
+#define MAX_HANDLE_SZ		128
+#endif
+
 /*
  * Helper function used to obtain fsid and file_handle for a given path.
  * Used by test files correlated to FAN_REPORT_FID functionality.


### PR DESCRIPTION
`MAX_HANDLE_SZ` is used since version 20200515 and https://github.com/linux-test-project/ltp/commit/d20a3e8f9a794e0659277acfa9fbcf7454ba4631

However, it is not defined by uclibc, so define it if needed to avoid the following build failure:

```
fanotify.h:171:11: error: 'MAX_HANDLE_SZ' undeclared here (not in a function)
  171 |  char buf[MAX_HANDLE_SZ];
```

Fixes:
 - http://autobuild.buildroot.org/results/fb0a67b15482e76b379b4b4d9c43b45bb0fccae1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>