### PR TITLE
stress/sem_init: fix build break

### DIFF
--- a/testcases/open_posix_testsuite/stress/threads/sem_init/s-c1.c
+++ b/testcases/open_posix_testsuite/stress/threads/sem_init/s-c1.c
@@ -372,6 +372,7 @@ int main(int argc, char *argv[])
 
 		PASSED;
 	}
+}
 
 /***
  * The next function will seek for the better model for each series of measurements.


### PR DESCRIPTION
stress/sem_init: fix build break

testcases/open_posix_testsuite/stress/threads/sem_init/s-c1.c: In function ‘main’:
testcases/open_posix_testsuite/stress/threads/sem_init/s-c1.c:747:2: error: expected declaration or statement at end of input
  747 |  }
      |  ^
