### PR TITLE
Remove 'static' before struct definition

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/fork/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/fork/2-1.c
@@ -48,7 +48,7 @@
 #include "posixtest.h"
 #include "mem_pattern.h"
 
-static struct test_struct {
+struct test_struct {
 	char one;
 	short two;
 	int three;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/1-2.c
@@ -156,7 +156,7 @@ static struct _scenar {
 
 #define NSCENAR (sizeof(scenarii)/sizeof(scenarii[0]))
 
-static struct testdata {
+struct testdata {
 	int count;		/* number of children currently waiting */
 	pthread_cond_t cnd;
 	pthread_mutex_t mtx;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/4-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_broadcast/4-2.c
@@ -56,7 +56,7 @@ static unsigned long count_sig;
 
 static sigset_t usersigs;
 
-static struct thestruct {
+struct thestruct {
 	int sig;
 #ifdef WITH_SYNCHRO
 	sem_t *sem;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_create/1-6.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_create/1-6.c
@@ -141,7 +141,7 @@ static void run_hp_threads(int sched_policy, int sched_prio)
 
 }
 
-static struct params {
+struct params {
 	int sched_policy;
 	int sched_priority;
 };
@@ -177,7 +177,7 @@ static void *do_test(void *arg)
 	return NULL;
 }
 
-static struct tcase {
+struct tcase {
 	int sched_policy;
 	int prio;
 };

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_detach/4-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_detach/4-3.c
@@ -62,7 +62,7 @@ static unsigned long count_sig;
 static long sleep_time;
 static sigset_t usersigs;
 
-static struct thestruct {
+struct thestruct {
 	int sig;
 #ifdef WITH_SYNCHRO
 	sem_t *sem;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_join/6-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_join/6-3.c
@@ -57,7 +57,7 @@ static unsigned long count_sig;
 
 static sigset_t usersigs;
 
-static struct thestruct {
+struct thestruct {
 	int sig;
 #ifdef WITH_SYNCHRO
 	sem_t *sem;

--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/16-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/16-1.c
@@ -42,7 +42,7 @@
  * Add more if desired.
  */
 
-static struct sig_info {
+struct sig_info {
 	int sig;
 	char *sig_name;
 	char caught;


### PR DESCRIPTION
Signed-off-by:  Krzysztof Dynowski <k.dynowski@samsung.com>