### PR TITLE
exec_with_inh.c: Remove unused argc and argv from main function

### DIFF
--- a/testcases/kernel/security/cap_bound/exec_with_inh.c
+++ b/testcases/kernel/security/cap_bound/exec_with_inh.c
@@ -38,7 +38,7 @@
 char *TCID = "exec_with_inh";
 int TST_TOTAL = 1;
 
-int main(int argc, char *argv[])
+int main(void)
 {
 #if HAVE_SYS_CAPABILITY_H
 #if HAVE_DECL_PR_CAPBSET_DROP


### PR DESCRIPTION
Fixes Warnings:
  exec_with_inh.c:41:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
  exec_with_inh.c:41:26: warning: unused parameter ‘argv’ [-Wunused-parameter

Signed-off-by: Tree Davies <tdavies@darkphysics.net>