### PR TITLE
utils: Fix compiler warnings for comparison of different signedness

### DIFF
--- a/utils/benchmark/ebizzy-0.3/ebizzy.c
+++ b/utils/benchmark/ebizzy-0.3/ebizzy.c
@@ -230,7 +230,7 @@ static void touch_mem(char *dest, size_t size)
 {
 	int i;
 	if (touch_pages) {
-		for (i = 0; i < size; i += page_size)
+		for (i = 0; i < (long)size; i += page_size)
 			*(dest + i) = 0xff;
 	}
 }
@@ -281,14 +281,14 @@ static void my_memcpy(void *dest, void *src, size_t len)
 	char *s = (char *)src;
 	int i;
 
-	for (i = 0; i < len; i++)
+	for (i = 0; i < (long)len; i++)
 		d[i] = s[i];
 	return;
 }
 
 static void allocate(void)
 {
-	int i;
+	unsigned int i;
 
 	mem = alloc_mem(chunks * sizeof(record_t *));
 
@@ -313,7 +313,7 @@ static void allocate(void)
 
 static void write_pattern(void)
 {
-	int i, j;
+	unsigned int i, j;
 
 	for (i = 0; i < chunks; i++) {
 		for (j = 0; j < chunk_size / record_size; j++)

--- a/utils/sctp/testlib/sctputil.c
+++ b/utils/sctp/testlib/sctputil.c
@@ -97,7 +97,7 @@ test_print_message(int sk, struct msghdr *msg, size_t msg_len)
 {
 	sctp_cmsg_data_t *data;
 	struct cmsghdr *cmsg;
-	int i;
+	unsigned int i;
 	int done = 0;
 	char save;
 	union sctp_notification *sn;
@@ -117,7 +117,7 @@ test_print_message(int sk, struct msghdr *msg, size_t msg_len)
 		printf("DATA(%d):  ", msg_len);
 		while ( msg_len > 0 ) {
 			char *text;
-			int len;
+			unsigned int len;
 
 			text = msg->msg_iov[index].iov_base;
 			len = msg->msg_iov[index].iov_len;
@@ -248,7 +248,7 @@ test_check_buf_data(void *buf, int datalen, int msg_flags,
 			 "Got a datamsg of unexpected length:%d, expected length:%d",
 			  datalen, expected_datalen);
 
-	if ((msg_flags & ~0x80000000) != expected_msg_flags)
+	if (((int)(msg_flags & ~0x80000000)) != expected_msg_flags)
 		tst_brkm(TBROK, tst_exit,
 			 "Unexpected msg_flags:0x%x expecting:0x%x",
 			  msg_flags, expected_msg_flags);

--- a/utils/sctp/testlib/sctputil.h
+++ b/utils/sctp/testlib/sctputil.h
@@ -189,9 +189,9 @@ static inline int test_accept(int sk, struct sockaddr *addr, socklen_t *addrlen)
 static inline int test_send(int sk, const void *msg, size_t len, int flags)
 {
 	int error = send(sk, msg, len, flags);
-        if (len != error)
-                tst_brkm(TBROK, tst_exit, "send: error:%d errno:%d",
-			 error, errno);
+	long length = (long)len;
+	if (length != error)
+		tst_brkm(TBROK, tst_exit, "send: error:%d errno:%d", error, errno);
 	return error;
 }
 
@@ -199,9 +199,9 @@ static inline int test_sendto(int sk, const void *msg, size_t len, int flags,
 			      const struct sockaddr *to, socklen_t tolen)
 {
 	int error = sendto(sk, msg, len, flags, to, tolen);
-        if (len != error)
-                tst_brkm(TBROK, tst_exit, "sendto: error:%d errno:%d",
-			 error, errno);
+	long length = (long)len;
+	if (length != error)
+		tst_brkm(TBROK, tst_exit, "sendto: error:%d errno:%d", error, errno);
 	return error;
 }
 
@@ -273,9 +273,10 @@ static inline int test_sctp_sendmsg(int s, const void *msg, size_t len,
 				    uint16_t stream_no, uint32_t timetolive,
 				    uint32_t context)
 {
+	long length = (long)len;
 	int error = sctp_sendmsg(s, msg, len, to, tolen, ppid, flags, stream_no,
 	  		         timetolive, context);
-	if (len != error)
+	if (length != error)
 		tst_brkm(TBROK, tst_exit, "sctp_sendmsg: error:%d errno:%d",
 			 error, errno);
 	return error;			
@@ -285,8 +286,9 @@ static inline int test_sctp_send(int s, const void *msg, size_t len,
 				 const struct sctp_sndrcvinfo *sinfo, 
 				 int flags)
 {
+	long length = (long)len;
 	int error = sctp_send(s, msg, len, sinfo, flags);
-	if (len != error)
+	if (length != error)
 		tst_brkm(TBROK, tst_exit, "sctp_send: error:%d errno:%d",
 			 error, errno);
 	return error;			


### PR DESCRIPTION
Fixes 172 warnings of:
- warning: comparison of integer expressions of different signedness:
  ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
- warning: comparison of integer expressions of different signedness:
  ‘int’ and ‘unsigned int’ [-Wsign-compare]

Signed-off-by: Tree Davies <tdavies@darkphysics.net>