### PR TITLE
kernel/syscalls: Fix compiler warnings for comparison of different si…

### DIFF
--- a/testcases/kernel/syscalls/chmod/chmod01.c
+++ b/testcases/kernel/syscalls/chmod/chmod01.c
@@ -122,7 +122,7 @@ int main(int ac, char **av)
 					 "stat(%s) failed", TESTFILE);
 			stat_buf.st_mode &= ~S_IFREG;
 
-			if (stat_buf.st_mode == mode)
+			if (stat_buf.st_mode == (unsigned int)mode)
 				tst_resm(TPASS, "Functionality of "
 					 "chmod(%s, %#o) successful",
 					 TESTFILE, mode);

--- a/testcases/kernel/syscalls/chown/chown05.c
+++ b/testcases/kernel/syscalls/chown/chown05.c
@@ -128,9 +128,9 @@ int main(int ac, char **av)
 			}
 			if (stat(TESTFILE, &stat_buf) == -1)
 				tst_brkm(TFAIL, cleanup, "stat failed");
-			if (user_id == -1)
+			if ((int)user_id == -1)
 				user_id = test_cases[i - 1].user_id;
-			if (group_id == -1)
+			if ((int)group_id == -1)
 				group_id = test_cases[i - 1].group_id;
 
 			if (stat_buf.st_uid != user_id ||

--- a/testcases/kernel/syscalls/cma/process_vm_readv03.c
+++ b/testcases/kernel/syscalls/cma/process_vm_readv03.c
@@ -223,7 +223,7 @@ static void child_invoke(int *bufsz_arr)
 	count = 0;
 	nr_error = 0;
 	for (i = 0; i < NUM_LOCAL_VECS; i++) {
-		for (j = 0; j < local[i].iov_len; j++) {
+		for (j = 0; j < (int)local[i].iov_len; j++) {
 			expect = count % 256;
 			actual = ((unsigned char *)local[i].iov_base)[j];
 			if (expect != actual) {

--- a/testcases/kernel/syscalls/dup2/dup204.c
+++ b/testcases/kernel/syscalls/dup2/dup204.c
@@ -119,7 +119,7 @@ void cleanup(void)
 {
 	int i;
 
-	for (i = 0; i < ARRAY_SIZE(fd); i++) {
+	for (i = 0; i < (int)ARRAY_SIZE(fd); i++) {
 		close(fd[i]);
 		close(nfd[i]);
 	}

--- a/testcases/kernel/syscalls/epoll/epoll-ltp.c
+++ b/testcases/kernel/syscalls/epoll/epoll-ltp.c
@@ -549,7 +549,7 @@ int test_epoll_ctl(int epoll_fd)
 							for (index = 1;
 							     index < 64;
 							     index++) {
-								if (ev_ptr->events != epoll_events[index]) {
+								if ((int)ev_ptr->events != epoll_events[index]) {
 									expected_errno
 									    =
 									    EINVAL;
@@ -649,8 +649,7 @@ int test_epoll_ctl(int epoll_fd)
 							  RES_PASS_RETV_MAT_ERRNO_IGN)))
 						{
 							if (result >
-							    (sizeof
-							     (result_strings) /
+							   (int)(sizeof(result_strings) /
 							     sizeof(const char
 								    *))) {
 								/* Returned a result which has no corresponding text description */

--- a/testcases/kernel/syscalls/fcntl/fcntl01.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl01.c
@@ -154,7 +154,7 @@ int main(int ac, char **av)
 			tst_resm(TFAIL, "unexpected flags, got 0x%x, "
 				 "expected 0x%x", flags, 1);
 
-		for (i = 0; i < ARRAY_SIZE(fd); i++)
+		for (i = 0; i < (int)ARRAY_SIZE(fd); i++)
 			close(fd[i]);
 		for (i = 0; i < 8; i++) {
 			sprintf(fname, "./fcntl%d.%d", i, mypid);

--- a/testcases/kernel/syscalls/fork/fork04.c
+++ b/testcases/kernel/syscalls/fork/fork04.c
@@ -144,7 +144,7 @@ static void child_environment(void)
 
 	fildes = creat(OUTPUT_FILE, 0700);
 
-	for (index = 0; index < NUMBER_OF_ENVIRON; index++) {
+	for (index = 0; index < (int)NUMBER_OF_ENVIRON; index++) {
 		memset(msg, 0, MAX_LINE_LENGTH);
 
 		var = getenv(environ_list[index]);
@@ -243,7 +243,7 @@ void parent_environment(void)
 	char *var;
 
 	fildes = SAFE_OPEN(cleanup, OUTPUT_FILE, O_RDWR);
-	for (index = 0; index < NUMBER_OF_ENVIRON; index++) {
+	for (index = 0; index < (int)NUMBER_OF_ENVIRON; index++) {
 		ret = read(fildes, tmp_line, MAX_LINE_LENGTH);
 		if (ret == 0) {
 			tst_resm(TBROK,

--- a/testcases/kernel/syscalls/getrusage/getrusage04.c
+++ b/testcases/kernel/syscalls/getrusage/getrusage04.c
@@ -118,14 +118,14 @@ int main(int argc, char *argv[])
 				tst_resm(TINFO, "utime:%12luus; stime:%12luus",
 					 usage.ru_utime.tv_usec,
 					 usage.ru_stime.tv_usec);
-				if (udelta > 1000 + (BIAS_MAX * factor_nr)) {
+				if ((long)udelta > 1000 + (BIAS_MAX * factor_nr)) {
 					sprintf(msg_string,
 						"utime increased > %ldus:",
 						1000 + BIAS_MAX * factor_nr);
 					tst_brkm(TFAIL, cleanup, msg_string,
 						 " delta = %luus", udelta);
 				}
-				if (sdelta > 1000 + (BIAS_MAX * factor_nr)) {
+				if ((long)sdelta > 1000 + (BIAS_MAX * factor_nr)) {
 					sprintf(msg_string,
 						"stime increased > %ldus:",
 						1000 + BIAS_MAX * factor_nr);

--- a/testcases/kernel/syscalls/getxattr/getxattr01.c
+++ b/testcases/kernel/syscalls/getxattr/getxattr01.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 	for (lc = 0; TEST_LOOPING(lc); lc++) {
 		tst_count = 0;
 
-		for (i = 0; i < ARRAY_SIZE(tc); i++) {
+		for (i = 0; i < (int)ARRAY_SIZE(tc); i++) {
 			TEST(getxattr(tc[i].fname, tc[i].key, tc[i].value,
 				      tc[i].size));
 
@@ -161,7 +161,7 @@ static void setup(void)
 	}
 
 	/* Prepare test cases */
-	for (i = 0; i <  ARRAY_SIZE(tc); i++) {
+	for (i = 0; i <  (int)ARRAY_SIZE(tc); i++) {
 		tc[i].value = malloc(BUFFSIZE);
 		if (tc[i].value == NULL) {
 			tst_brkm(TBROK | TERRNO, cleanup,

--- a/testcases/kernel/syscalls/lchown/lchown01.c
+++ b/testcases/kernel/syscalls/lchown/lchown01.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 					 SFILE, TEST_ERRNO);
 			}
 
-			if (user_id == -1) {
+			if ((int)user_id == -1) {
 				if (i > 0)
 					user_id =
 					    test_cases[i - 1].user_id;
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 					user_id = geteuid();
 			}
 
-			if (group_id == -1) {
+			if ((int)group_id == -1) {
 				if (i > 0)
 					group_id =
 					    test_cases[i - 1].group_id;

--- a/testcases/kernel/syscalls/mmap/mmap001.c
+++ b/testcases/kernel/syscalls/mmap/mmap001.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
 
 		tst_resm(TINFO, "touching mmaped memory");
 
-		for (i = 0; i < memsize; i++) {
+		for (i = 0; i < (int)memsize; i++) {
 			array[i] = (char)i;
 		}
 

--- a/testcases/kernel/syscalls/mmap/mmap01.c
+++ b/testcases/kernel/syscalls/mmap/mmap01.c
@@ -164,7 +164,7 @@ static void setup(void)
 	}
 
 	/* Write some data into temporary file */
-	if (write(fildes, write_buf, strlen(write_buf)) != strlen(write_buf)) {
+	if (write(fildes, write_buf, strlen(write_buf)) != (long)strlen(write_buf)) {
 		tst_brkm(TFAIL, cleanup, "writing to %s", TEMPFILE);
 	}
 

--- a/testcases/kernel/syscalls/mmap/mmap02.c
+++ b/testcases/kernel/syscalls/mmap/mmap02.c
@@ -144,7 +144,7 @@ static void setup(void)
 	}
 
 	/* Write test buffer contents into temporary file */
-	if (write(fildes, tst_buff, page_sz) < page_sz) {
+	if (write(fildes, tst_buff, page_sz) < (int)page_sz) {
 		free(tst_buff);
 		tst_brkm(TFAIL | TERRNO, cleanup,
 			 "writing to %s failed", TEMPFILE);

--- a/testcases/kernel/syscalls/mmap/mmap03.c
+++ b/testcases/kernel/syscalls/mmap/mmap03.c
@@ -175,7 +175,7 @@ static void setup(void)
 	}
 
 	/* Write test buffer contents into temporary file */
-	if (write(fildes, tst_buff, page_sz) < page_sz) {
+	if (write(fildes, tst_buff, page_sz) < (long)page_sz) {
 		free(tst_buff);
 		tst_brkm(TFAIL | TERRNO, cleanup, "writing to %s failed",
 			 TEMPFILE);

--- a/testcases/kernel/syscalls/mmap/mmap04.c
+++ b/testcases/kernel/syscalls/mmap/mmap04.c
@@ -147,7 +147,7 @@ static void setup(void)
 	}
 
 	/* Write test buffer contents into temporary file */
-	if (write(fildes, tst_buff, page_sz) < page_sz) {
+	if (write(fildes, tst_buff, page_sz) < (long)page_sz) {
 		free(tst_buff);
 		tst_brkm(TFAIL, cleanup, "writing to %s failed", TEMPFILE);
 	}

--- a/testcases/kernel/syscalls/mmap/mmap05.c
+++ b/testcases/kernel/syscalls/mmap/mmap05.c
@@ -153,7 +153,7 @@ static void setup(void)
 	}
 
 	/* Write test buffer contents into temporary file */
-	if (write(fildes, tst_buff, page_sz) != page_sz) {
+	if (write(fildes, tst_buff, page_sz) != (int)page_sz) {
 		free(tst_buff);
 		tst_brkm(TFAIL, cleanup, "writing to %s failed", TEMPFILE);
 	}

--- a/testcases/kernel/syscalls/mmap/mmap06.c
+++ b/testcases/kernel/syscalls/mmap/mmap06.c
@@ -128,7 +128,7 @@ static void setup(void)
 	}
 
 	/* Write test buffer contents into temporary file */
-	if (write(fildes, tst_buff, page_sz) < page_sz) {
+	if (write(fildes, tst_buff, page_sz) < (int)page_sz) {
 		free(tst_buff);
 		tst_brkm(TFAIL, cleanup, "writing to %s failed", TEMPFILE);
 	}

--- a/testcases/kernel/syscalls/mmap/mmap07.c
+++ b/testcases/kernel/syscalls/mmap/mmap07.c
@@ -131,7 +131,7 @@ static void setup(void)
 	}
 
 	/* Write test buffer contents into temporary file */
-	if (write(fildes, tst_buff, page_sz) < page_sz) {
+	if (write(fildes, tst_buff, page_sz) < (int)page_sz) {
 		free(tst_buff);
 		tst_brkm(TFAIL, cleanup, "writing to %s failed", TEMPFILE);
 	}

--- a/testcases/kernel/syscalls/mmap/mmap08.c
+++ b/testcases/kernel/syscalls/mmap/mmap08.c
@@ -122,7 +122,7 @@ static void setup(void)
 	}
 
 	/* Write test buffer contents into temporary file */
-	if (write(fildes, tst_buff, page_sz) != page_sz) {
+	if (write(fildes, tst_buff, page_sz) != (int)page_sz) {
 		free(tst_buff);
 		tst_brkm(TFAIL, cleanup, "writing to %s failed", TEMPFILE);
 	}

--- a/testcases/kernel/syscalls/mount/mount03.c
+++ b/testcases/kernel/syscalls/mount/mount03.c
@@ -208,7 +208,7 @@ int test_rwflag(int i, int cnt)
 
 		/* Write the buffer data into file */
 		if (write(fildes, write_buffer, strlen(write_buffer)) !=
-		    strlen(write_buffer)) {
+		    (long)strlen(write_buffer)) {
 			tst_resm(TWARN | TERRNO, "writing to %s failed", file);
 			close(fildes);
 			return 1;

--- a/testcases/kernel/syscalls/move_pages/move_pages_support.c
+++ b/testcases/kernel/syscalls/move_pages/move_pages_support.c
@@ -67,11 +67,11 @@ int alloc_pages_on_nodes(void **pages, unsigned int num, int *nodes)
 	size_t onepage = get_page_size();
 #endif
 
-	for (i = 0; i < num; i++) {
+	for (i = 0; i < (int)num; i++) {
 		pages[i] = NULL;
 	}
 
-	for (i = 0; i < num; i++) {
+	for (i = 0; i < (int)num; i++) {
 		char *page;
 
 #ifdef HAVE_NUMA_V2
@@ -88,7 +88,7 @@ int alloc_pages_on_nodes(void **pages, unsigned int num, int *nodes)
 		page[0] = i;
 	}
 
-	if (i == num)
+	if (i == (int)num)
 		return 0;
 
 	free_pages(pages, num);

--- a/testcases/kernel/syscalls/msync/msync02.c
+++ b/testcases/kernel/syscalls/msync/msync02.c
@@ -140,7 +140,7 @@ void setup(void)
 		tst_brkm(TBROK | TERRNO, cleanup, "lseek failed");
 
 	/* Write the string in write_buf at the 100 byte offset */
-	if (write(fildes, write_buf, strlen(write_buf)) != strlen(write_buf))
+	if (write(fildes, write_buf, strlen(write_buf)) != (long)strlen(write_buf))
 		tst_brkm(TBROK | TERRNO, cleanup, "write failed");
 }
 

--- a/testcases/kernel/syscalls/remap_file_pages/remap_file_pages01.c
+++ b/testcases/kernel/syscalls/remap_file_pages/remap_file_pages01.c
@@ -149,14 +149,14 @@ static void test_nonlinear(int fd)
 	char *data = NULL;
 	int i, j, repeat = 2;
 
-	for (i = 0; i < cache_pages; i++) {
+	for (i = 0; i < (int)cache_pages; i++) {
 		char *page = cache_contents + i * page_sz;
 
-		for (j = 0; j < page_words; j++)
+		for (j = 0; j < (int)page_words; j++)
 			page[j] = i;
 	}
 
-	if (write(fd, cache_contents, cache_sz) != cache_sz) {
+	if (write(fd, cache_contents, cache_sz) != (int)cache_sz) {
 		tst_resm(TFAIL,
 			 "Write Error for \"cache_contents\" to \"cache_sz\" of %zu (errno=%d : %s)",
 			 cache_sz, errno, strerror(errno));
@@ -173,7 +173,7 @@ static void test_nonlinear(int fd)
 	}
 
 again:
-	for (i = 0; i < window_pages; i += 2) {
+	for (i = 0; i < (int)window_pages; i += 2) {
 		char *page = data + i * page_sz;
 
 		if (remap_file_pages(page, page_sz * 2, 0,
@@ -186,12 +186,12 @@ again:
 		}
 	}
 
-	for (i = 0; i < window_pages; i++) {
+	for (i = 0; i < (int)window_pages; i++) {
 		/*
 		 * Double-check the correctness of the mapping:
 		 */
 		if (i & 1) {
-			if (data[i * page_sz] != window_pages - i) {
+			if (data[i * page_sz] != ((int)window_pages) - i) {
 				tst_resm(TFAIL,
 					 "hm, mapped incorrect data, "
 					 "data[%d]=%d, (window_pages-%d)=%zu",
@@ -200,7 +200,7 @@ again:
 				cleanup(data);
 			}
 		} else {
-			if (data[i * page_sz] != window_pages - i - 2) {
+			if (data[i * page_sz] != ((int)window_pages) - i - 2) {
 				tst_resm(TFAIL,
 					 "hm, mapped incorrect data, "
 					 "data[%d]=%d, (window_pages-%d-2)=%zu",

--- a/testcases/kernel/syscalls/setrlimit/setrlimit01.c
+++ b/testcases/kernel/syscalls/setrlimit/setrlimit01.c
@@ -151,8 +151,7 @@ static void test2(void)
 
 		bytes = write(fd, buf, 26);
 		if (bytes != 10) {
-			if (write(pipefd[1], &bytes, sizeof(bytes))
-			    < sizeof(bytes)) {
+			if (write(pipefd[1], &bytes, sizeof(bytes)) < (long)sizeof(bytes)) {
 				perror("child: write to pipe failed");
 			}
 			close(pipefd[1]);	/* EOF */
@@ -177,7 +176,7 @@ static void test2(void)
 		break;
 	case 3:
 		close(pipefd[1]);	/* close unused write end */
-		if (read(pipefd[0], &bytes, sizeof(bytes)) < sizeof(bytes))
+		if (read(pipefd[0], &bytes, sizeof(bytes)) < (long)sizeof(bytes))
 			tst_resm(TFAIL, "parent: reading pipe failed");
 
 		close(pipefd[0]);

--- a/testcases/kernel/syscalls/symlink/symlink01.c
+++ b/testcases/kernel/syscalls/symlink/symlink01.c
@@ -598,7 +598,7 @@ struct tcses *get_tcs_info(char *ptr)
 	}
 #endif
 
-	for (ctr = 0; ctr < (sizeof(all_tcses) / sizeof(struct tcses)); ctr++) {
+	for (ctr = 0; ctr < (int)(sizeof(all_tcses) / sizeof(struct tcses)); ctr++) {
 		if (strcmp(ptr, all_tcses[ctr].tcid) == 0 ||
 		    strcmp(ptr, all_tcses[ctr].syscall) == 0) {
 			tcs_ptr = &all_tcses[ctr];
@@ -1879,7 +1879,7 @@ void help(void)
 
 	printf("   -T id  Determines which tests cases to execute:\n");
 
-	for (ind = 0; ind < sizeof(all_tcses) / sizeof(struct tcses); ind++) {
+	for (ind = 0; ind < (int)sizeof(all_tcses) / sizeof(struct tcses); ind++) {
 		printf("  %s/%s - %s\n", all_tcses[ind].tcid,
 		       all_tcses[ind].syscall, all_tcses[ind].desc);
 	}


### PR DESCRIPTION
…gnedness

Fixes 45 instances of warning type:
- warning: comparison of integer expressions of different signedness

Signed-off-by: Tree Davies <tdavies@darkphysics.net>