### PR TITLE
runltp: Generate HTML output file in read-only fs

### DIFF
--- a/runltp
+++ b/runltp
@@ -320,9 +320,9 @@ main()
             /*)
                 HTMLFILE="$OPTARG";;
             *)
-                HTMLFILE="$LTPROOT/output/$OPTARG";;
+                HTMLFILE="$LTPROOT/output/$OPTARG"
+                ALT_DIR_OUT=1;;
             esac
-            ALT_DIR_OUT=1
             ALT_HTML_OUT=1;;
         h)  usage;;
 


### PR DESCRIPTION
[ Upstream commit c5e8c14a8df94963b2417eaf23f7be5d76483db3 ]

solves the issue of running LTP from a read-only filesystem. But
generating HTML output file fails. This commit solves the issue of
generating HTML file in read-only filesystem.

Signed-off-by: Bhargav Das <bhargav_das@mentor.com>