### PR TITLE
kernel/syscalls/memfd_create: fix case2's tst_res argument

### DIFF
--- a/testcases/kernel/syscalls/memfd_create/memfd_create03.c
+++ b/testcases/kernel/syscalls/memfd_create/memfd_create03.c
@@ -110,7 +110,7 @@ static void test_def_pagesize(int fd)
 		} else {
 			tst_res(TFAIL,
 				"munmap(%p, %dkB) suceeded unexpectedly\n",
-				mem, i);
+				mem, i/1024);
 			return;
 		}
 	}


### PR DESCRIPTION
this test case forget to divided by 1024 when conveting byte to kbyte
Signed-off-by: ouyangciyan <zintown@qq.com>