### PR TITLE
In tpci_user/tpci.c ->static void test_run(void),

### DIFF
--- a/testcases/kernel/device-drivers/pci/tpci_kernel/ltp_tpci.c
+++ b/testcases/kernel/device-drivers/pci/tpci_kernel/ltp_tpci.c
@@ -321,6 +321,9 @@ static int test_slot_scan(void)
 
 	prk_info("scan pci slot");
 
+	if ((num % 8) != 0)
+		return TPASS;
+
 	ret = pci_scan_slot(bus, num);
 	if (ret >= 0) {
 		prk_info("found '%d' devices from scan slot", ret);


### PR DESCRIPTION
the code scan the devices on a bus one by one.
Then it calls pci_scan_slot() here.
But pci_scan_slot cannot be called with non-zero devfn
(i.e. devfn % 8 shall be zero).

Signed-off-by: Tianyu <tianyu@kylinos.cn>