### PR TITLE
[WIP] Wait for complete input provided by `seq`

### DIFF
--- a/runtest/smoketest
+++ b/runtest/smoketest
@@ -11,5 +11,5 @@ symlink01 symlink01
 stat04 symlink01 -T stat04
 utime01A symlink01 -T utime01
 rename01A symlink01 -T rename01
-splice02 seq 1 20 | splice02
+splice02 (seq 1 20 || :) | splice02
 route4-change-dst route-change-dst.sh

--- a/runtest/syscalls
+++ b/runtest/syscalls
@@ -1446,7 +1446,7 @@ socketpair02 socketpair02
 sockioctl01 sockioctl01
 
 splice01 splice01
-splice02 seq 1 20000 | splice02
+splice02 (seq 1 20000 || :) | splice02
 splice03 splice03
 splice04 splice04
 splice05 splice05


### PR DESCRIPTION
`splice02` may exit before `seq` therefore broken pipe occurs. All kudos to Fabian

* ticket: [splice02 fails in JeOS](https://progress.opensuse.org/issues/77260)

Signed-off-by: Martin Loviska <mloviska@suse.com>
Suggested-by: Fabian Vogt <fvogt@suse.com>