### PR TITLE
Treewide: fix spelling mistake "exitting" -> "exiting"

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -92,10 +92,10 @@ cleanup(). So if a there is a cleanup() callback in the tst\_test structure
 it's executed. The cleanup() callback runs in a special context where the
 tst\_brk(TBROK, ...) calls are converted into tst\_res(TWARN, ...) calls. This
 is because we found out that carrying on with partially broken cleanup is
-usually better option than exitting it in the middle.
+usually better option than exiting it in the middle.
 
 The test cleanup() is also called by the tst\_brk() handler in order to cleanup
-before exitting the test process, hence it must be able to cope even with
+before exiting the test process, hence it must be able to cope even with
 partial test setup. Usually it suffices to make sure to clean up only
 resources that already have been set up and to do that in an inverse order that
 we did in setup().

--- a/lib/newlib_tests/variant.c
+++ b/lib/newlib_tests/variant.c
@@ -22,7 +22,7 @@ static void do_test(void)
 	break;
 	}
 
-	tst_res(TINFO, "test() function exitting normaly");
+	tst_res(TINFO, "test() function exiting normaly");
 }
 
 static void setup(void)

--- a/lib/tst_test.c
+++ b/lib/tst_test.c
@@ -1236,7 +1236,7 @@ static void alarm_handler(int sig LTP_ATTRIBUTE_UNUSED)
 	if (++sigkill_retries > 10) {
 		WRITE_MSG("Cannot kill test processes!\n");
 		WRITE_MSG("Congratulation, likely test hit a kernel bug.\n");
-		WRITE_MSG("Exitting uncleanly...\n");
+		WRITE_MSG("Exiting uncleanly...\n");
 		_exit(TFAIL);
 	}
 }

--- a/lib/tst_timer_test.c
+++ b/lib/tst_timer_test.c
@@ -267,7 +267,7 @@ void do_timer_test(long long usec, unsigned int nsamples)
 	cur_sample = 0;
 	for (i = 0; i < (int)nsamples; i++) {
 		if (sample(CLOCK_MONOTONIC, usec)) {
-			tst_res(TINFO, "sampling function failed, exitting");
+			tst_res(TINFO, "sampling function failed, exiting");
 			return;
 		}
 	}

--- a/testcases/kernel/controllers/freezer/vfork.c
+++ b/testcases/kernel/controllers/freezer/vfork.c
@@ -21,7 +21,7 @@
  *
  * vfork <num> times, stopping after each vfork. TODO: Requires an external process
  * to send SIGCONT to goto the next vfork. <num> SIGCONT signals must be
- * received before exitting.
+ * received before exiting.
  *
  * We can't do anything but execve or _exit in vfork'd processes
  * so we use ptrace vfork'd processes in order to pause then during each

--- a/testcases/kernel/syscalls/setrlimit/setrlimit01.c
+++ b/testcases/kernel/syscalls/setrlimit/setrlimit01.c
@@ -117,7 +117,7 @@ static void test2(void)
 	 * Since we would be altering the filesize in the child,
 	 * we need to "sync", ie. fflush the parent's write buffers
 	 * here.  This is because the child will inherit the parent's
-	 * write buffer, and while exitting it would try to fflush it.
+	 * write buffer, and while exiting it would try to fflush it.
 	 * Since its filesize is truncated to only 10 bytes, the
 	 * fflush attempt would fail, and the child would exit with
 	 * an wired value!  So, it is essential to fflush the parent's

--- a/testcases/network/nfsv4/locks/locktests.c
+++ b/testcases/network/nfsv4/locks/locktests.c
@@ -563,7 +563,7 @@ void masterClient(void)
 	/* Receive the END(ish) instruction */
 
 	/* Repeat it to the slaves */
-	printf("Exitting...\n");
+	printf("Exiting...\n");
 	serverSendLocal();
 
 	/* Ok, we can quit */


### PR DESCRIPTION
Fix spelling mistakes of Exiting/exiting.

Signed-off-by: Colin Ian King <colin.king@canonical.com>