### PR TITLE
Hyperv getrusage04

### DIFF
--- a/include/tst_cpu.h
+++ b/include/tst_cpu.h
@@ -16,6 +16,7 @@ long tst_ncpus_available(void);
 #define VIRT_IBMZ	3	/* ibm system z */
 #define VIRT_IBMZ_LPAR	4	/* ibm system z lpar */
 #define VIRT_IBMZ_ZVM	5	/* ibm system z zvm */
+#define VIRT_HYPERV	6	/* Microsoft Hyper-V */
 #define VIRT_OTHER	0xffff	/* unrecognized hypervisor */
 
 int tst_is_virt(int virt_type);

--- a/lib/tst_virt.c
+++ b/lib/tst_virt.c
@@ -138,6 +138,9 @@ static int try_systemd_detect_virt(void)
 	if (!strncmp("zvm", virt_type, 3))
 		return VIRT_IBMZ_ZVM;
 
+	if (!strncmp("microsoft", virt_type, 9))
+		return VIRT_HYPERV;
+
 	return VIRT_OTHER;
 }
 

--- a/testcases/kernel/syscalls/getrusage/getrusage04.c
+++ b/testcases/kernel/syscalls/getrusage/getrusage04.c
@@ -197,7 +197,7 @@ static void setup(void)
 {
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
-	if (tst_is_virt(VIRT_XEN) || tst_is_virt(VIRT_KVM))
+	if (tst_is_virt(VIRT_XEN) || tst_is_virt(VIRT_KVM) || tst_is_virt(VIRT_HYPERV))
 		tst_brkm(TCONF, NULL, "This testcase is not supported on this"
 		        " virtual machine.");
 


### PR DESCRIPTION
Add basic detection of Microsoft Hyper-V hypervisor using systemd.
Other way would be to check for PCI devices (Microsoft Corporation
Hyper-V virtual VGA) or via DMI tables (dmidecoder).

Detection of Hyper-V is important to skip failing getrusage04 test.

See also https://bugs.launchpad.net/bugs/1905396

Signed-off-by: Krzysztof Kozlowski <krzysztof.kozlowski@canonical.com>