### PR TITLE
controllers/cpuset_memory_spread:

### DIFF
--- a/testcases/kernel/controllers/cpuset/cpuset_funcs.sh
+++ b/testcases/kernel/controllers/cpuset/cpuset_funcs.sh
@@ -187,15 +187,23 @@ cleanup()
 
 	find "$CPUSET" -type d | sort | sed -n '2,$p' | tac | while read subdir
 	do
+		if [ "$subdir" != "/dev/cpuset/sys" ]; then
 		while read pid
-		do
-			/bin/kill -9 $pid > /dev/null 2>&1
-			if [ $? -ne 0 ]; then
-				tst_brkm TFAIL "Couldn't kill task - "\
-							"$pid in the cpuset"
-			fi
-		done < "$subdir/tasks"
-		rmdir "$subdir"
+			do
+				/bin/kill -9 $pid > /dev/null 2>&1
+				if [ $? -ne 0 ]; then
+					tst_brkm TFAIL "Couldn't kill task - "\
+								"$pid in the cpuset 1"
+				fi
+			done < "$subdir/tasks"
+		fi
+
+		if [  "$subdir" == "/dev/cpuset/sys"  ]; then
+			cgdelete -r cpuset:sys
+		else
+			rmdir "$subdir"
+		fi
+
 		if [ $? -ne 0 ]; then
 			tst_brkm TFAIL "Couldn't remove subdir - "
 						"$subdir in the cpuset"

--- a/testcases/kernel/controllers/cpuset/cpuset_memory_spread_test/cpuset_memory_spread_testset.sh
+++ b/testcases/kernel/controllers/cpuset/cpuset_memory_spread_test/cpuset_memory_spread_testset.sh
@@ -194,6 +194,7 @@ result_check()
 general_memory_spread_test()
 {
 	local cpusetpath="$CPUSET/1"
+        local cpusetpathsys="$CPUSET/sys"
 	local is_spread="$1"
 	local cpu_list="$2"
 	local node_list="$3"
@@ -206,6 +207,12 @@ general_memory_spread_test()
 		tst_resm TFAIL "set general group parameter failed."
 		return 1
 	fi
+	cpuset_set "$cpusetpathsys" "$cpu_list" "$node_list" "0" 2> $CPUSET_TMP/stderr
+	if [ $? -ne 0 ]; then
+		cpuset_log_error $CPUSET_TMP/stderr
+		tst_resm TFAIL "set general group parameter failed for sys."
+		return 1
+	fi
 
 	/bin/echo "$is_spread" > "$cpusetpath/cpuset.memory_spread_page" 2> $CPUSET_TMP/stderr
 	if [ $? -ne 0 ]; then
@@ -213,6 +220,19 @@ general_memory_spread_test()
 		tst_resm TFAIL "set spread value failed."
 		return 1
 	fi
+
+	/bin/echo "$is_spread" > "$cpusetpathsys/cpuset.memory_spread_page" 2> $CPUSET_TMP/stderr
+	if [ $? -ne 0 ]; then
+		cpuset_log_error $CPUSET_TMP/stderr
+		tst_resm TFAIL "set spread value failed for sys."
+		return 1
+	fi
+
+        array=`ps -elf |grep -v "\["|awk '{print $4}'|xargs echo`
+        for element in ${array[@]}
+        do
+		/bin/echo $element > "$cpusetpathsys/tasks" 2>  /dev/null #$CPUSET_TMP/stderr
+        done
 
 	/bin/echo "$test_pid" > "$cpusetpath/tasks" 2> $CPUSET_TMP/stderr
 	if [ $? -ne 0 ]; then
@@ -224,6 +244,7 @@ general_memory_spread_test()
 	# we'd better drop the caches before we test page cache.
 	sync
 	/bin/echo 3 > /proc/sys/vm/drop_caches 2> $CPUSET_TMP/stderr
+	sleep 3
 	if [ $? -ne 0 ]; then
 		cpuset_log_error $CPUSET_TMP/stderr
 		tst_resm TFAIL "drop caches failed."


### PR DESCRIPTION
When the cpuset_mem_hog program is run and
the number of FilePages in the process is counted,
the Page Cache of other processes interferes with the process,
causing the use case to fail
Other Page Cache comes from two aspects:
1. After releasing Page Cache and slab cache:
   echo 3> /proc/sys/vm/drop_caches,
   some processes or kernel threads will reload files into Page Cache
2. During the running of the cpuset_mem_hog program,
   there will be some processes using Page Cache

amendment:
1, The first type of Page Cache: solve it by adding a delay after
   the echo 3> /proc/sys/vm/drop_caches command is executed:
   sleep 3 # 3 is an empirical value, and it may have a
   different value without the environment
2, The second type of Page Cache: by modifying the strategy,
   create a new sys: /dev/cpuset/cpuset/sys under the cpuset in the cgroup,
   and then add all user processes except cpuset_mem_hog to the cgroup,
   and set the strategy for the CPU and memory nodes
   Same as /dev/cpuset/cpuset/1