### PR TITLE
syscalls/ioctl_ns05.c, ioctl_ns06.c: Fix too small buffer for path

### DIFF
--- a/testcases/kernel/syscalls/ioctl/ioctl_ns05.c
+++ b/testcases/kernel/syscalls/ioctl/ioctl_ns05.c
@@ -59,10 +59,10 @@ static void run(void)
 	if (pid == -1)
 		tst_brk(TBROK | TERRNO, "ltp_clone failed");
 
-	char child_namespace[20];
+	char child_namespace[30];
 	int my_fd, child_fd, parent_fd;
 
-	sprintf(child_namespace, "/proc/%i/ns/pid", pid);
+	snprintf(child_namespace, sizeof(child_namespace), "/proc/%i/ns/pid", pid);
 	my_fd = SAFE_OPEN("/proc/self/ns/pid", O_RDONLY);
 	child_fd = SAFE_OPEN(child_namespace, O_RDONLY);
 	parent_fd = ioctl(child_fd, NS_GET_PARENT);

--- a/testcases/kernel/syscalls/ioctl/ioctl_ns06.c
+++ b/testcases/kernel/syscalls/ioctl/ioctl_ns06.c
@@ -51,14 +51,14 @@ static int child(void *arg LTP_ATTRIBUTE_UNUSED)
 
 static void run(void)
 {
-	char child_namespace[20];
+	char child_namespace[30];
 
 	pid_t pid = ltp_clone(CLONE_NEWUSER | SIGCHLD, &child, 0,
 		STACK_SIZE, child_stack);
 	if (pid == -1)
 		tst_brk(TBROK | TERRNO, "ltp_clone failed");
 
-	sprintf(child_namespace, "/proc/%i/ns/user", pid);
+	snprintf(child_namespace, sizeof(child_namespace), "/proc/%i/ns/user", pid);
 	int my_fd, child_fd, parent_fd;
 
 	my_fd = SAFE_OPEN("/proc/self/ns/user", O_RDONLY);


### PR DESCRIPTION
Resize the buffer used for paths into /proc/<pid> to grant enough space
for long PIDs. While at it, replace sprintf with snprintf to avoid
	buffer overflows if we ever ran out of space again.

Signed-off-by: Marius Hillenbrand <mhillen@linux.ibm.com>

Fixes #847 