### PR TITLE
lib: tst_device: sleep before unbinding the loop device

### DIFF
--- a/lib/tst_device.c
+++ b/lib/tst_device.c
@@ -236,6 +236,8 @@ int tst_detach_device_by_fd(const char *dev, int dev_fd)
 	/* keep trying to clear LOOPDEV until we get ENXIO, a quick succession
 	 * of attach/detach might not give udev enough time to complete */
 	for (i = 0; i < 40; i++) {
+		usleep(500000);
+
 		ret = ioctl(dev_fd, LOOP_CLR_FD, 0);
 
 		if (ret && (errno == ENXIO))
@@ -247,8 +249,6 @@ int tst_detach_device_by_fd(const char *dev, int dev_fd)
 				 dev, tst_strerrno(errno));
 			return 1;
 		}
-
-		usleep(50000);
 	}
 
 	tst_resm(TWARN,


### PR DESCRIPTION
When running ltp/ltpstress test that kernel will generats io error
of loop device, which was due to loop io request doesn't finished
dispatch before unbinding the loop device. and this patch fixed io
error issue by add the logic that sleep for a shor period before
unbinding the loop device.

Signed-off-by: Yinbo Zhu <zhuyinbo@loongson.cn>