### PR TITLE
memcg_failcnt.sh: Append numerical suffix to the test func

### DIFF
--- a/testcases/kernel/controllers/memcg/functional/memcg_failcnt.sh
+++ b/testcases/kernel/controllers/memcg/functional/memcg_failcnt.sh
@@ -16,7 +16,7 @@ TST_TEST_DATA="--mmap-anon --mmap-file --shm"
 MEMORY_LIMIT=$PAGESIZE
 MEMORY_TO_ALLOCATE=$((MEMORY_LIMIT * 2))
 
-test()
+test1()
 {
 	ROD echo $MEMORY_LIMIT \> memory.limit_in_bytes
 


### PR DESCRIPTION
memcg_failcnt.sh: Append numerical suffix to the test func

Currently the execution of the testcase "memcg_failcnt.sh" is reporting TBROK,
since the "memcg_testfunc" function in "memcg_lib.sh" is expecting a
numerical suffix.

This patch fixes the issue, post which the testcase execution is "TPASS".

Signed-off-by: santwana <santwana@linux.vnet.ibm.com>