### PR TITLE
kernel/crypto: add the testcase of OSCCA SM3 secure hash

### DIFF
--- a/testcases/kernel/crypto/af_alg01.c
+++ b/testcases/kernel/crypto/af_alg01.c
@@ -66,6 +66,7 @@ static const char * const hash_algs[] = {
 	"sha256", "sha256-generic",
 	"sha3-256", "sha3-256-generic",
 	"sha3-512", "sha3-512-generic",
+	"sm3", "sm3-generic",
 };
 
 static void do_test(unsigned int i)

--- a/testcases/kernel/crypto/crypto_user02.c
+++ b/testcases/kernel/crypto/crypto_user02.c
@@ -39,7 +39,8 @@ static const char * const ALGORITHM_CANDIDATES[] = {
 	"hmac(sha224-generic)",
 	"hmac(sha256-generic)",
 	"hmac(sha384-generic)",
-	"hmac(md5-generic)"
+	"hmac(md5-generic)",
+	"hmac(sm3-generic)"
 };
 
 static const char* algorithm = NULL;


### PR DESCRIPTION
Add the testcases of OSCCA SM3 secure hash (OSCCA GM/T 0004-2012 SM3)
generic hash in both af_alg01.c and crypto_user02.c.

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>