### PR TITLE
include/tst_timer.h: avoid redefinition of kernel structures

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,9 @@ AC_CHECK_TYPES([struct xt_entry_match, struct xt_entry_target],,,[
 #include <linux/netfilter_ipv4/ip_tables.h>
 ])
 
+AC_CHECK_TYPES([struct __kernel_old_timeval, struct __kernel_old_timespec, struct __kernel_timespec,
+                struct __kernel_old_itimerspec, struct __kernel_itimerspec],,,[#include <sys/socket.h>])
+
 # Tools knobs
 
 # Bash

--- a/include/tst_timer.h
+++ b/include/tst_timer.h
@@ -99,34 +99,42 @@ static inline long long tst_timeval_diff_ms(struct timeval t1,
 
 typedef __kernel_long_t	__kernel_old_time_t;
 
-#ifndef __kernel_old_timeval
+#ifndef HAVE_STRUCT___KERNEL_OLD_TIMEVAL
 struct __kernel_old_timeval {
 	__kernel_old_time_t	tv_sec;		/* seconds */
 	__kernel_suseconds_t	tv_usec;	/* microseconds */
 };
 #endif
 
+#ifndef HAVE_STRUCT___KERNEL_OLD_TIMESPEC
 struct __kernel_old_timespec {
 	__kernel_old_time_t	tv_sec;		/* seconds */
 	__kernel_old_time_t	tv_nsec;	/* nanoseconds */
 };
+#endif
 
 typedef long long __kernel_time64_t;
 
+#ifndef HAVE_STRUCT___KERNEL_TIMESPEC
 struct __kernel_timespec {
 	__kernel_time64_t       tv_sec;                 /* seconds */
 	long long               tv_nsec;                /* nanoseconds */
 };
+#endif
 
+#ifndef HAVE_STRUCT___KERNEL_OLD_ITIMERSPEC
 struct __kernel_old_itimerspec {
 	struct __kernel_old_timespec it_interval;    /* timer period */
 	struct __kernel_old_timespec it_value;       /* timer expiration */
 };
+#endif
 
+#ifndef HAVE_STRUCT___KERNEL_ITIMERSPEC
 struct __kernel_itimerspec {
 	struct __kernel_timespec it_interval;    /* timer period */
 	struct __kernel_timespec it_value;       /* timer expiration */
 };
+#endif
 #endif
 
 enum tst_ts_type {


### PR DESCRIPTION
`ifndef` doesn't work on `struct` resulting in the following build failure (e.g. on sh4 which includes `linux/time_types.h` as soon as `sys/socket.h` is included):

```
In file included from ../../include/libsigwait.h:11,
                 from sigwait.c:9:
../../include/tst_timer.h:103:8: error: redefinition of ‘struct __kernel_old_timeval’
  103 | struct __kernel_old_timeval {
      |        ^~~~~~~~~~~~~~~~~~~~
In file included from /builds/sh4/host/sh4-buildroot-linux-uclibc/sysroot/usr/include/asm/sockios.h:5,
                 from /builds/sh4/host/sh4-buildroot-linux-uclibc/sysroot/usr/include/asm-generic/socket.h:6,
                 from /builds/sh4/host/sh4-buildroot-linux-uclibc/sysroot/usr/include/asm/socket.h:1,
                 from /builds/sh4/host/sh4-buildroot-linux-uclibc/sysroot/usr/include/bits/socket.h:362,
                 from /builds/sh4/host/sh4-buildroot-linux-uclibc/sysroot/usr/include/sys/socket.h:39,
                 from ../../include/tst_safe_net.h:9,
                 from ../../include/tst_test.h:96,
                 from ../../include/libsigwait.h:10,
                 from sigwait.c:9:
/builds/sh4/host/sh4-buildroot-linux-uclibc/sysroot/usr/include/linux/time_types.h:25:8: note: originally defined here
   25 | struct __kernel_old_timeval {
      |        ^~~~~~~~~~~~~~~~~~~~
In file included from ../../include/libsigwait.h:11,
                 from sigwait.c:9:
../../include/tst_timer.h:109:8: error: redefinition of ‘struct __kernel_old_timespec’
  109 | struct __kernel_old_timespec {
      |        ^~~~~~~~~~~~~~~~~~~~~
```

Fixes:
 - https://bugs.busybox.net/show_bug.cgi?id=13786

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>