### PR TITLE
Update clock_gettime04.c

### DIFF
--- a/testcases/kernel/syscalls/clock_gettime/clock_gettime04.c
+++ b/testcases/kernel/syscalls/clock_gettime/clock_gettime04.c
@@ -35,7 +35,7 @@ clockid_t clks[] = {
 };
 
 static gettime_t ptr_vdso_gettime, ptr_vdso_gettime64;
-static long long delta = 5;
+static long long delta = 11;
 
 static inline int do_vdso_gettime(gettime_t vdso, clockid_t clk_id, void *ts)
 {


### PR DESCRIPTION
Only considers that the configuration is 250Hz when delta = 5.
When 100Hz is configured, the delta must be greater than 10ms.
So modify delta = 11.
Resolve:
1) TFAIL: CLOCK_REALTIME_COARSE(vDSO with old kernel spec): Difference between successive readings greater than 5 ms (2): 10
2) TFAIL: CLOCK_MONOTONIC_COARSE(vDSO with old kernel spec): Difference between successive readings greater than 5 ms (2): 10