### PR TITLE
cmdlib.sh: Fix confusing error message in exists() helper

### DIFF
--- a/testcases/lib/cmdlib.sh
+++ b/testcases/lib/cmdlib.sh
@@ -103,7 +103,7 @@ exists()
 {
     for cmd in $*; do
         if ! command -v $cmd >/dev/null 2>&1; then
-            tst_resm TCONF "$1: command $2 not found."
+            tst_resm TCONF "command $cmd not found."
             exit 32
         fi
     done


### PR DESCRIPTION
Error message was confusing:
```
  exists awk ftp rsh
  TCONF awk: command ftp not found.
```
this was printed when rsh does not exist, which is a complete mess.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>