### PR TITLE
memcg_stress_test.sh: fix Available memory formula

### DIFF
--- a/testcases/kernel/controllers/memcg/stress/memcg_stress_test.sh
+++ b/testcases/kernel/controllers/memcg/stress/memcg_stress_test.sh
@@ -29,7 +29,7 @@ setup()
 
 	echo 3 > /proc/sys/vm/drop_caches
 	sleep 2
-	local mem_free=`cat /proc/meminfo | grep MemFree | awk '{ print $2 }'`
+	local mem_free=`cat /proc/meminfo | grep MemAvailable | awk '{ print $2 }'`
 	local swap_free=`cat /proc/meminfo | grep SwapFree | awk '{ print $2 }'`
 	local pgsize=`tst_getconf PAGESIZE`
 


### PR DESCRIPTION
In NUMA architecture, Sometimes too many node nodes will cause the system to retain too much free memory. Make the value of "memFree" in the /proc /meminfo file greater than the real available value. This resulted in memory over allocation (OOM) for this test.

For example, this is a arm server‘s content of /proc/meminfo which has 128 cpus and 16 nodes :
# cat /proc/meminfo 
MemTotal:  		536018688 kB
MemFree:		512151936 kB
MemAvailable:		472947264 kB
Buffers:		   8384 kB
Cached:		1789376 kB
SwapCached:		      0 KB
Active:		1924288 kB
Inactive:		1445888 kB
Active(anom):		1608832 kB
Inactive(amon)	  40512 kB
Active(file):		 315456 kB
Inactive(file):     1405376 kB
Unevictable:		  31744 KBhad recent pushes 20 minutes ago
....

Therefore, it is suggested to change the "memFree" in the calculation formula to "memavailable". Of course, this will give the system more memory pressure, but also the script reserve half of the swap to alleviate this problem.