### PR TITLE
fix undefined behavior.

### DIFF
--- a/testcases/kernel/sched/tool/time-schedule.c
+++ b/testcases/kernel/sched/tool/time-schedule.c
@@ -494,7 +494,7 @@ static unsigned long get_num_switches()
     [RETURNS] The number of context switches on success, else 0.
 */
 {
-	unsigned long val;
+	unsigned long val = 0;
 	FILE *fp;
 	char line[256], name[64];
 


### PR DESCRIPTION
in your code, you don't initialize `val` and you don't check the result of running `sscanf`.
therefore, in case of an incorrect call to `sscanf`, function `get_num_switches` may return a random value.
the easiest fix is to initialize `val` to zero