### PR TITLE
memcg_test_3: don't send signal when parent unexpectedly exited

### DIFF
--- a/testcases/kernel/controllers/memcg/regression/memcg_test_3.c
+++ b/testcases/kernel/controllers/memcg/regression/memcg_test_3.c
@@ -21,6 +21,7 @@
 
 static volatile int sigcounter;
 static struct tst_cg_group *test_cg;
+static pid_t ppid;
 
 static void sighandler(int sig LTP_ATTRIBUTE_UNUSED)
 {
@@ -29,8 +30,8 @@ static void sighandler(int sig LTP_ATTRIBUTE_UNUSED)
 
 static void do_child(void)
 {
-	while (1)
-		SAFE_KILL(getppid(), SIGUSR1);
+	while (getppid() == ppid)
+		SAFE_KILL(ppid, SIGUSR1);
 
 	exit(0);
 }
@@ -40,6 +41,7 @@ static void do_test(void)
 	pid_t cpid;
 
 	SAFE_SIGNAL(SIGUSR1, sighandler);
+	ppid = getpid();
 
 	cpid = SAFE_FORK();
 	if (cpid == 0)


### PR DESCRIPTION
When the parent process exits abnormally for some reason, the
parent process of the child process will become process 1.
In this case, the child process should not send signal to
process 1.

So we compare the realy parent pid and the saved parent pid,the
child process should exit when they has mismatched.

Signed-off-by: Lingling Li <lilingling@loongson.cn>
Signed-off-by: Hongchen Zhang <zhanghongchen@loongson.cn>