### PR TITLE
Increase Errormsg size.

### DIFF
--- a/lib/tlibio.c
+++ b/lib/tlibio.c
@@ -195,7 +195,7 @@ static volatile int Rec_signal;
 static volatile int Received_callback = 0;	/* number of callbacks received */
 static volatile int Rec_callback;
 #endif
-static char Errormsg[500];
+static char Errormsg[PATH_MAX*2];
 static int Debug_level = 0;
 
 /***********************************************************************


### PR DESCRIPTION
```
tlibio.c:1442:40: warning: ‘%s’ directive writing up to 4095 bytes into a region of size 486 [-Wformat-overflow=]
 1442 |                                 "%s/%d %s failed, fd:%d, nbyte:%d errno=%d %s",
      |                                        ^~
 1443 |                                 __FILE__, __LINE__, Lio_SysCall, fd, size,
      |                                                     ~~~~~~~~~~~
```