### PR TITLE
Remove duplicate include of <sys/mount.h>

### DIFF
--- a/testcases/kernel/syscalls/statx/statx09.c
+++ b/testcases/kernel/syscalls/statx/statx09.c
@@ -18,7 +18,6 @@
  */
 
 #define _GNU_SOURCE
-#include <sys/mount.h>
 #include <stdlib.h>
 #include "tst_test.h"
 #include "lapi/fs.h"


### PR DESCRIPTION
<sys/mount.h> is already included by lapi/mount.h.

This fixes build with glibc 2.36+

Signed-off-by: Khem Raj <raj.khem@gmail.com>