### PR TITLE
fanotify: fix compile complain

### DIFF
--- a/testcases/kernel/syscalls/fanotify/fanotify21.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify21.c
@@ -33,7 +33,7 @@
 #define MOUNT_PATH	"fs_mnt"
 #define TEST_FILE	MOUNT_PATH "/testfile"
 
-static struct pidfd_fdinfo_t {
+struct pidfd_fdinfo_t {
 	int pos;
 	int flags;
 	int mnt_id;


### PR DESCRIPTION
```
fanotify21.c:42:1: warning: useless storage class specifier in empty declaration
   42 | };
      | ^
```