### PR TITLE
Fix: compile warning: "NSEC_PER_SEC" redefined

### DIFF
--- a/testcases/kernel/syscalls/clock_settime/clock_settime02.c
+++ b/testcases/kernel/syscalls/clock_settime/clock_settime02.c
@@ -14,7 +14,6 @@
 #include "tst_safe_clocks.h"
 
 #define DELTA_SEC 10
-#define NSEC_PER_SEC (1000000000L)
 
 static void *bad_addr;
 


### PR DESCRIPTION
Fix
```
clock_settime02.c:17: warning: "NSEC_PER_SEC" redefined
   17 | #define NSEC_PER_SEC (1000000000L)
      |
In file included from ../../../../include/tst_timer.h:20,
                 from ../../../../include/time64_variants.h:20,
                 from clock_settime02.c:12:
../../../../include/lapi/common_timers.h:15: note: this is the location of the previous definition
   15 | #define NSEC_PER_SEC (1000000000LL)
      |
CC testcases/kernel/syscalls/clock_settime/clock_settime02
```