### PR TITLE
syscalls/prctl04: Fix false positive report when SECCOMP_MODE_FILTER …

### DIFF
--- a/testcases/kernel/syscalls/prctl/prctl04.c
+++ b/testcases/kernel/syscalls/prctl/prctl04.c
@@ -158,12 +158,14 @@ static void check_filter_mode(int val)
 
 	TEST(prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &strict));
 	if (TST_RET == -1) {
-		if (TST_ERR == EINVAL)
+		if (TST_ERR == EINVAL) {
 			tst_res(TCONF,
 				"kernel doesn't support SECCOMP_MODE_FILTER");
-		else
+			exit(1);
+		} else {
 			tst_res(TFAIL | TERRNO,
 				"prctl(PR_SET_SECCOMP) sets SECCOMP_MODE_FILTER failed");
+		}
 		return;
 	}
 
@@ -208,7 +210,7 @@ static void verify_prctl(unsigned int n)
 			return;
 		}
 
-		if (tc->pass_flag == 2)
+		if (!(WIFEXITED(status) && WEXITSTATUS(status) == 1) && tc->pass_flag == 2)
 			tst_res(TFAIL,
 				"SECCOMP_MODE_FILTER permits exit() unexpectedly");
 	}


### PR DESCRIPTION
…is not supported

The child process really should not receive the expected siganl, SIGSYS, when kernel doesn't support SECCOMP_MODE_FILTER.

This patch makes the child process exit with 1 to indicate such case.

Before this patch:
root@xilinx-zynq:~# /opt/ltp/testcases/bin/prctl04 tst_test.c:1431: TINFO: Timeout per run is 0h 05m 00s ---- snip ----
prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER prctl04.c:204: TFAIL: SECCOMP_MODE_FILTER permits exit() unexpectedly prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER

After this patch:
root@xilinx-zynq:~# /opt/ltp/testcases/bin/prctl04 tst_test.c:1431: TINFO: Timeout per run is 0h 05m 00s ---- snip ----
prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER prctl04.c:154: TCONF: kernel doesn't support SECCOMP_MODE_FILTER

Signed-off-by: He Zhe <zhe.he@windriver.com>

[ type description here; PLEASE REMOVE THIS LINE AND THE LINES BELOW BEFORE SUBMITTING THIS PULL REQUEST ]

Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/

There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).

LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.ozlabs.org/project/ltp/list/.
