### PR TITLE
mmap-corruption01: remove temporary file after test finished

### DIFF
--- a/testcases/kernel/mem/mmapstress/mmap-corruption01.c
+++ b/testcases/kernel/mem/mmapstress/mmap-corruption01.c
@@ -177,5 +177,6 @@ int main(int argc, char **argv)
 void finish(int sig)
 {
 	printf("mmap-corruption PASSED\n");
+	tst_rmdir();
 	exit(0);
 }


### PR DESCRIPTION
After the test succesfully finished it leaves behind a file in /tmp, which might impact other tests afterwards that rely on space in /tmp as well. These tests then might fail with:

```
tst_device.c:284: TWARN: Failed to create test_dev.img: ENOSPC (28)
tst_device.c:345: TBROK: Failed to acquire device
```