### PR TITLE
Enlarging the buffer to accommodate multi-extended attribute file system

### DIFF
--- a/testcases/kernel/syscalls/flistxattr/flistxattr01.c
+++ b/testcases/kernel/syscalls/flistxattr/flistxattr01.c
@@ -47,7 +47,7 @@ static int has_attribute(const char *list, int llen, const char *attr)
 
 static void verify_flistxattr(void)
 {
-	char buf[64];
+	char buf[128];
 
 	TEST(flistxattr(fd, buf, sizeof(buf)));
 	if (TST_RET == -1) {


### PR DESCRIPTION
Some OS have many EA, and caused the flistxattr01 test to fail