### PR TITLE
Add containers/share to PATH when call init_ltp_netspace

### DIFF
--- a/testcases/lib/tst_net.sh
+++ b/testcases/lib/tst_net.sh
@@ -128,6 +128,9 @@ tst_net_require_ipv6()
 
 init_ltp_netspace()
 {
+	PATH="$PWD/../../testcases/kernel/containers/share/:$PATH"
+	tst_res TINFO "PATH='$PATH'"
+
 	local pid
 
 	if [ ! -f /var/run/netns/ltp_ns -a -z "$LTP_NETNS" ]; then


### PR DESCRIPTION
Fix following scenario: ns_xxx command not found error

LTP_SHELL_API_TESTS=shell/net/tst_rhost_run.sh make test-shell
make -C "lib"
-f "/home/ltp/lib/Makefile" all
make[1]: Entering directory '/home/ltp/lib'
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/ltp/lib'
#echo /home/ltp
#echo -s
set -e; /home/ltp/lib/newlib_tests/runtest.sh -b /home/ltp -s
runtest TINFO: PATH='/home/ltp/testcases/lib:/home/ltp/lib/newlib_tests/../../testcases/lib/:/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin'
runtest TINFO: KCONFIG_PATH='config02'
runtest TINFO: === Run SHELL tests ===
runtest TINFO: * shell/net/tst_rhost_run.sh
tst_rhost_run 1 TINFO: tst_rhost_run: cmd: [ -f /proc/net/if_inet6 ]
tst_rhost_run 1 TINFO: NETNS: sh -c " [ -f /proc/net/if_inet6 ] || echo RTERR" 2>&1
/bin/sh: line 1: ns_create: command not found <===
tst_rhost_run 1 TBROK: ns_create net,mnt failed
tst_rhost_run 1 TINFO: AppArmor enabled, this may affect test results
tst_rhost_run 1 TINFO: it can be disabled with TST_DISABLE_APPARMOR=1 (requires super/root)
tst_rhost_run 1 TINFO: loaded AppArmor profiles: none