### PR TITLE
flistxattr01: enlarging the buffer to accommodate multi-extended attribute OS

### DIFF
--- a/testcases/kernel/syscalls/flistxattr/flistxattr01.c
+++ b/testcases/kernel/syscalls/flistxattr/flistxattr01.c
@@ -47,7 +47,7 @@ static int has_attribute(const char *list, int llen, const char *attr)
 
 static void verify_flistxattr(void)
 {
-	char buf[64];
+	char buf[128];
 
 	TEST(flistxattr(fd, buf, sizeof(buf)));
 	if (TST_RET == -1) {


### PR DESCRIPTION
The security policy of the KylinOS needs to automatically assign extended attributes to newly created temporary files. At present, the number of extended attributes in the system is quite large, and the size of the cache area for obtaining extended attributes in the flistxattr01 test case is limited. If we continue to add extended attributes, the list of extended attributes will exceed 64 bytes, and an error will be reported (ERANGE) like this:

kylin@kylin-XYABC:/opt/ltp/testcases/bin$ sudo ./flistxattr01 tst_test.c:1244: INFO: Timeout per run is 0h 05m 00s flistxattr01.c:63: FAIL: flistxattr() failed: ERANGE (34)

Summary:
passed   0
failed   1
skipped  0
warnings 0

Considering these extended properties of our OS is necessary,so we recommend fixing this to pass the test

Signed-off-by: Frank He <hexiaoxiao@kylinos.cn>

[ type description here; PLEASE REMOVE THIS LINE AND THE LINES BELOW BEFORE SUBMITTING THIS PULL REQUEST ]

<!--
* Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/
There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).
LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.ozlabs.org/project/ltp/list/.

* Commits should be signed: Signed-off-by: Your Name <me@example.org>, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

* Commit message should be meaningful, following common style
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes
https://cbea.ms/git-commit/

* New code should follow Linux kernel coding style, see
https://www.kernel.org/doc/html/latest/process/coding-style.html.
You can run 'make check' or 'make check-foo' in the folder with modified code to check style and common errors.

* For more tips check
https://github.com/linux-test-project/ltp/wiki/Maintainer-Patch-Review-Checklist
https://github.com/linux-test-project/ltp/wiki/Test-Writing-Guidelines
https://github.com/linux-test-project/ltp/wiki/C-Test-API
https://github.com/linux-test-project/ltp/wiki/Shell-Test-API
https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial
-->
