### PR TITLE
Fix shell script syntax error

### DIFF
--- a/testcases/kernel/controllers/freezer/vfork_freeze.sh
+++ b/testcases/kernel/controllers/freezer/vfork_freeze.sh
@@ -60,7 +60,7 @@ TMPLOG="$TMPDIR/${0##*/}.$$.txt"
 # create new processes. The vfork'ed processes then sleep, causing the
 # parent process ($sample_proc) to enter the TASK_UNINTERRUPTIBLE state
 # for the duration of the sleep.
-function vfork_sleep()
+vfork_sleep()
 {
 	vfork -s$sample_sleep 1 -f "$TMPLOG" &
 	local rc=$?


### PR DESCRIPTION
Fix the below error,
```
$ sh -n testcases/kernel/controllers/freezer/vfork_freeze.sh
   testcases/kernel/controllers/freezer/vfork_freeze.sh: 63: Syntax error: "(" unexpected
```

Signed-off-by: Vignesh Raman <vignesh.raman@collabora.com>