### PR TITLE
shell: add kernel version check

### DIFF
--- a/testcases/kernel/power_management/pm_include.sh
+++ b/testcases/kernel/power_management/pm_include.sh
@@ -25,6 +25,13 @@ check_arch() {
 	esac
 }
 
+check_kernel_version() {
+	if tst_kvcmp -ge "3.5"; then
+		tst_brkm TCONF "Kernel version not supported; not " \
+			"running testcases"
+	fi
+}
+
 check_config_options() {
 	if ( ! ${3} "${1}" ${2} | grep -v "#" > /dev/null ) ; then
 		tst_brkm TCONF "NOSUPPORT: current system dosen't support ${1}"

--- a/testcases/kernel/power_management/runpwtests_exclusive01.sh
+++ b/testcases/kernel/power_management/runpwtests_exclusive01.sh
@@ -26,6 +26,7 @@ export TST_TOTAL=2
 
 # Checking test environment
 check_arch
+check_kernel_version
 
 max_sched_mc=2
 max_sched_smt=2

--- a/testcases/kernel/power_management/runpwtests_exclusive02.sh
+++ b/testcases/kernel/power_management/runpwtests_exclusive02.sh
@@ -26,6 +26,7 @@ export TST_TOTAL=1
 
 # Checking test environment
 check_arch
+check_kernel_version
 
 max_sched_smt=2
 

--- a/testcases/kernel/power_management/runpwtests_exclusive03.sh
+++ b/testcases/kernel/power_management/runpwtests_exclusive03.sh
@@ -26,6 +26,7 @@ export TST_TOTAL=2
 
 # Checking test environment
 check_arch
+check_kernel_version
 
 max_sched_mc=2
 max_sched_smt=2

--- a/testcases/kernel/power_management/runpwtests_exclusive04.sh
+++ b/testcases/kernel/power_management/runpwtests_exclusive04.sh
@@ -26,6 +26,7 @@ export TST_TOTAL=2
 
 # Checking test environment
 check_arch
+check_kernel_version
 
 tst_require_cmds python3
 

--- a/testcases/kernel/power_management/runpwtests_exclusive05.sh
+++ b/testcases/kernel/power_management/runpwtests_exclusive05.sh
@@ -26,6 +26,7 @@ export TST_TOTAL=2
 
 # Checking test environment
 check_arch
+check_kernel_version
 
 max_sched_mc=2
 max_sched_smt=2


### PR DESCRIPTION
the "sched_mc_power_savings" interface has been removed since kernel version 3.5,
fix patch 8e7fbcb("sched: Remove stale power aware scheduling remnants and dysfunctional knobs"). 
do not execute this testcase on kernel versions 3.5 and above.

Signed-off-by: pengyu <pengyu@kylinos.cn>

<!--
* Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/
There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).
LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.ozlabs.org/project/ltp/list/.

* Commits should be signed: Signed-off-by: Your Name <me@example.org>, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

* Commit message should be meaningful, following common style
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes
https://cbea.ms/git-commit/

* New code should follow Linux kernel coding style, see
https://www.kernel.org/doc/html/latest/process/coding-style.html.
You can run 'make check' or 'make check-foo' in the folder with modified code to check style and common errors.

* For more tips check
https://github.com/linux-test-project/ltp/wiki/Maintainer-Patch-Review-Checklist
https://github.com/linux-test-project/ltp/wiki/Test-Writing-Guidelines
https://github.com/linux-test-project/ltp/wiki/C-Test-API
https://github.com/linux-test-project/ltp/wiki/Shell-Test-API
https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial
-->
