### PR TITLE
ima_kexec.sh: Remove check_policy_readable

### DIFF
--- a/testcases/kernel/security/integrity/ima/tests/ima_kexec.sh
+++ b/testcases/kernel/security/integrity/ima/tests/ima_kexec.sh
@@ -46,10 +46,8 @@ setup()
 		tst_brk TCONF "kernel image not found, specify path in \$IMA_KEXEC_IMAGE"
 	fi
 
-	if check_policy_readable; then
-		require_ima_policy_content "$REQUIRED_POLICY"
-		policy_readable=1
-	fi
+	require_ima_policy_content "$REQUIRED_POLICY"
+	policy_readable=1
 }
 
 kexec_failure_hint()


### PR DESCRIPTION
In ima_kexec.sh, check_policy_readable has been executed in require_ima_policy_content. Remove check_policy_readable; otherwise, it will miss ‘tst_brk TCONF’.

Signed-off-by: pengyu <pengyu@kylinos.cn>
<!--
* Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/
There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).
LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.ozlabs.org/project/ltp/list/.

* Commits should be signed: Signed-off-by: Your Name <me@example.org>, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

* Commit message should be meaningful, following common style
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes
https://cbea.ms/git-commit/

* New code should follow Linux kernel coding style, see
https://www.kernel.org/doc/html/latest/process/coding-style.html.
You can run 'make check' or 'make check-foo' in the folder with modified code to check style and common errors.

* For more tips check
https://github.com/linux-test-project/ltp/wiki/Maintainer-Patch-Review-Checklist
https://github.com/linux-test-project/ltp/wiki/Test-Writing-Guidelines
https://github.com/linux-test-project/ltp/wiki/C-Test-API
https://github.com/linux-test-project/ltp/wiki/Shell-Test-API
https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial
-->
