### PR TITLE
scsi_debug/tlibio/lio_[read,write]_buffer: Always return total amount of read/written bytes

### DIFF
--- a/lib/tlibio.c
+++ b/lib/tlibio.c
@@ -539,6 +539,8 @@ int lio_write_buffer(int fd,		/* open file descriptor */
 		long wrd)	/* to allow future features, use zero for now */
 {
 	int ret = 0;		/* syscall return or used to get random method */
+	int totally_written = 0;/* as we cycle writes in case of partial writes, */
+				/* we have to report up total bytes written */
 	char *io_type;		/* Holds string of type of io */
 	int omethod = method;
 	int listio_cmd;		/* Holds the listio/lio_listio cmd */
@@ -745,13 +747,14 @@ int lio_write_buffer(int fd,		/* open file descriptor */
 						fd, size, ret);
 					size -= ret;
 					buffer += ret;
+					totally_written += ret;
 				} else {
 					if (Debug_level > 1)
 						printf
 						    ("DEBUG %s/%d: write completed without error (ret %d)\n",
 						     __FILE__, __LINE__, ret);
 
-					return ret;
+					return totally_written + ret;
 				}
 			}
 			wait4sync_io(fd, 0);

--- a/lib/tlibio.c
+++ b/lib/tlibio.c
@@ -1112,6 +1112,8 @@ int lio_read_buffer(int fd,	/* open file descriptor */
 		long wrd)	/* to allow future features, use zero for now */
 {
 	int ret = 0;		/* syscall return or used to get random method */
+	int totally_read = 0;	/* as we cycle reads in case of partial reads, */
+				/* we have to report up total bytes read */
 	char *io_type;		/* Holds string of type of io */
 	int listio_cmd;		/* Holds the listio/lio_listio cmd */
 	int omethod = method;
@@ -1323,13 +1325,14 @@ int lio_read_buffer(int fd,	/* open file descriptor */
 						fd, size, ret);
 					size -= ret;
 					buffer += ret;
+					totally_read += ret;
 				} else {
 					if (Debug_level > 1)
 						printf
 						    ("DEBUG %s/%d: read completed without error (ret %d)\n",
 						     __FILE__, __LINE__, ret);
 
-					return ret;
+					return totally_read + ret;
 				}
 			}
 			wait4sync_io(fd, 1);


### PR DESCRIPTION
Sometimes we got failures like:

>  growfiles(gf217): 65884 growfiles.c/2262: 104203 tlibio.c/744 write(3, buf, 5000) returned=2288
>  growfiles(gf217): 65884 growfiles.c/1765: 104203 Hit max errors value of 1
>  gf217       1  TFAIL  :  growfiles.c:134: Test failed

Which looked strange as partial write is something usual and valid.
It turned out that lio_write_buffer() has the code cycle writes in case
of a partial write happens, but it anyway returns the amount of bytes
written by the LAST write.

And upper growfile() consider the returned amount from
lio_write_buffer() to be less than it tried to write and fails the
testcase.

Fix lio_write_buffer() to always return total bytes written, even in
case partial writes.

Similar for lio_read_buffer() , it needs to return total amount of read bytes in case of partial reads.

Signed-off-by: Konstantin Khorenko <khorenko@virtuozzo.com>