### PR TITLE
cpuset_memory_spread: change lowerlimit to 5000kb

### DIFF
--- a/testcases/kernel/controllers/cpuset/cpuset_memory_spread_test/cpuset_memory_spread_testset.sh
+++ b/testcases/kernel/controllers/cpuset/cpuset_memory_spread_test/cpuset_memory_spread_testset.sh
@@ -38,7 +38,7 @@ nr_mems=$N_NODES
 # on which it is running. The other nodes' slab space has littler change.(less
 # than 1000 kb).
 upperlimit=10000
-lowerlimit=2000
+lowerlimit=5000
 
 cpus_all="$(seq -s, 0 $((nr_cpus-1)))"
 mems_all="$(seq -s, 0 $((nr_mems-1)))"


### PR DESCRIPTION
When I test the cpuset_memory_spread case,this case FAIL too often. After dig into the code, I find out that the fowlloing things trigger the FAIL:
1) random events,the probability is very small and can be ignored 
2) get_meminfo which before send signal to test_pid 
3) account_memsinfo before result_check

About 2) and 3), we can increase the value of lowerlimit to keep the result as SUCCESS.After my testing, 5000kb is a reasonable value.
