### PR TITLE
testcases/kernel/syscalls/fcntl: define _LARGEFILE64_SOURCE

### DIFF
--- a/testcases/kernel/syscalls/fcntl/Makefile
+++ b/testcases/kernel/syscalls/fcntl/Makefile
@@ -17,6 +17,6 @@ include $(abs_srcdir)/../utils/newer_64.mk
 
 %_64: CPPFLAGS += -D_FILE_OFFSET_BITS=64
 
-CPPFLAGS		+= -D_GNU_SOURCE
+CPPFLAGS		+= -D_GNU_SOURCE -D_LARGEFILE64_SOURCE
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk


### PR DESCRIPTION
This is required for off64_t to be available on 32 bit musl systems.

Usage of off64_t was introduced in https://github.com/linux-test-project/ltp/commit/6f12ed8ef3c30552d63625f3ad60985663934719
