### PR TITLE
Fixed the log repeated printing problem of diotest

### DIFF
--- a/testcases/kernel/io/direct_io/diotest3.c
+++ b/testcases/kernel/io/direct_io/diotest3.c
@@ -292,6 +292,7 @@ int main(int argc, char *argv[])
 	}
 	unlink(filename);
 	free(pidlst);
+	fflush(stdout);
 	total++;
 
 	/* Testblock-2: Write with Direct IO, Read without */
@@ -309,6 +310,7 @@ int main(int argc, char *argv[])
 	}
 	unlink(filename);
 	free(pidlst);
+	fflush(stdout);
 	total++;
 
 	/* Testblock-3: Read, Write with Direct IO. */

--- a/testcases/kernel/io/direct_io/diotest6.c
+++ b/testcases/kernel/io/direct_io/diotest6.c
@@ -320,6 +320,7 @@ int main(int argc, char *argv[])
 	}
 	unlink(filename);
 	free(pidlst);
+	fflush(stdout);
 	total++;
 
 	/* Testblock-2: Write with Direct IO, Read without */
@@ -337,6 +338,7 @@ int main(int argc, char *argv[])
 	}
 	unlink(filename);
 	free(pidlst);
+	fflush(stdout);
 	total++;
 
 	/* Testblock-3: Read, Write with Direct IO. */


### PR DESCRIPTION
Fix the problem of repeated printing logs when the dio module specifies the output log file，This is a typetical buffer problem.The diotest6/diotes3 was designed third steps whole programe,every step will fork lots of process,If the cache subprocess is not cleaned up, the cache generated in the previous step will be copied, and then when each process exits, a large number of repeated prints will be generated.

Signed-off-by: Duncan.chu wqhaicyj@163.com

Oh,sorry.@metan-ucw This is my first time contributing code to the community, please forgive my misktake and I already changed the message.At last, Can you review my code? thanks :)