### PR TITLE
fix the display error in epoll_ctl

### DIFF
--- a/testcases/kernel/syscalls/epoll_ctl/epoll_ctl02.c
+++ b/testcases/kernel/syscalls/epoll_ctl/epoll_ctl02.c
@@ -67,7 +67,7 @@ static void setup(void)
 	events[1].data.fd = fd[1];
 
 	if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd[0], &events[0]))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static void cleanup(void)
@@ -85,7 +85,7 @@ static void cleanup(void)
 static void verify_epoll_ctl(unsigned int n)
 {
 	TST_EXP_FAIL(epoll_ctl(*tc[n].epfd, tc[n].opt, *tc[n].fd, tc[n].event),
-		     tc[n].exp_err, "epoll_clt(...) if %s", tc[n].desc);
+		     tc[n].exp_err, "epoll_ctl(...) if %s", tc[n].desc);
 }
 
 static struct tst_test test = {

--- a/testcases/kernel/syscalls/epoll_ctl/epoll_ctl03.c
+++ b/testcases/kernel/syscalls/epoll_ctl/epoll_ctl03.c
@@ -55,7 +55,7 @@ static void setup(void)
 	events.data.fd = fds[0];
 
 	if (epoll_ctl(epfd, EPOLL_CTL_ADD, fds[0], &events))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static void cleanup(void)

--- a/testcases/kernel/syscalls/epoll_ctl/epoll_ctl04.c
+++ b/testcases/kernel/syscalls/epoll_ctl/epoll_ctl04.c
@@ -36,7 +36,7 @@ static void setup(void)
 
 		events.data.fd = epfd;
 		if (epoll_ctl(new_epfd, EPOLL_CTL_ADD, epfd, &events))
-			tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+			tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 
 		epfd = new_epfd;
 	}
@@ -59,7 +59,7 @@ static void verify_epoll_ctl(void)
 
 	events.data.fd = epfd;
 	TST_EXP_FAIL(epoll_ctl(new_epfd, EPOLL_CTL_ADD, epfd, &events), EINVAL,
-		     "epoll_clt(..., EPOLL_CTL_ADD, ...) with number of nesting is 5");
+		     "epoll_ctl(..., EPOLL_CTL_ADD, ...) with number of nesting is 5");
 	SAFE_CLOSE(new_epfd);
 }
 

--- a/testcases/kernel/syscalls/epoll_ctl/epoll_ctl05.c
+++ b/testcases/kernel/syscalls/epoll_ctl/epoll_ctl05.c
@@ -40,12 +40,12 @@ static void setup(void)
 
 		events.data.fd = epfd;
 		if (epoll_ctl(new_epfd, EPOLL_CTL_ADD, epfd, &events))
-			tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+			tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 	}
 
 	events.data.fd = fd[0];
 	if (epoll_ctl(origin_epfd, EPOLL_CTL_DEL, fd[0], &events))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_DEL, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_DEL, ...)");
 }
 
 static void cleanup(void)
@@ -61,7 +61,7 @@ static void verify_epoll_ctl(void)
 {
 	events.data.fd = epfd;
 	TST_EXP_FAIL(epoll_ctl(origin_epfd, EPOLL_CTL_ADD, epfd, &events),
-		     ELOOP, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		     ELOOP, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static struct tst_test test = {

--- a/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01.c
+++ b/testcases/kernel/syscalls/epoll_pwait/epoll_pwait01.c
@@ -102,7 +102,7 @@ static void setup(void)
 
 	e.events = EPOLLIN;
 	if (epoll_ctl(efd, EPOLL_CTL_ADD, sfd[0], &e))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static void cleanup(void)

--- a/testcases/kernel/syscalls/epoll_pwait/epoll_pwait02.c
+++ b/testcases/kernel/syscalls/epoll_pwait/epoll_pwait02.c
@@ -42,7 +42,7 @@ static void setup(void)
 
 	e.events = EPOLLIN;
 	if (epoll_ctl(efd, EPOLL_CTL_ADD, sfd[0], &e))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 	SAFE_WRITE(SAFE_WRITE_ALL, sfd[1], "w", 1);
 }
 

--- a/testcases/kernel/syscalls/epoll_pwait/epoll_pwait03.c
+++ b/testcases/kernel/syscalls/epoll_pwait/epoll_pwait03.c
@@ -50,7 +50,7 @@ static void setup(void)
 
 	e.events = EPOLLIN;
 	if (epoll_ctl(efd, EPOLL_CTL_ADD, sfd[0], &e))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static void cleanup(void)

--- a/testcases/kernel/syscalls/epoll_pwait/epoll_pwait04.c
+++ b/testcases/kernel/syscalls/epoll_pwait/epoll_pwait04.c
@@ -38,7 +38,7 @@ static void setup(void)
 
 	e.events = EPOLLIN;
 	if (epoll_ctl(efd, EPOLL_CTL_ADD, sfd[0], &e))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 	SAFE_WRITE(SAFE_WRITE_ALL, sfd[1], "w", 1);
 
 	bad_addr = tst_get_bad_addr(NULL);

--- a/testcases/kernel/syscalls/epoll_pwait/epoll_pwait05.c
+++ b/testcases/kernel/syscalls/epoll_pwait/epoll_pwait05.c
@@ -46,7 +46,7 @@ static void setup(void)
 
 	e.events = EPOLLIN;
 	if (epoll_ctl(efd, EPOLL_CTL_ADD, sfd[0], &e))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 	SAFE_WRITE(SAFE_WRITE_ALL, sfd[1], "w", 1);
 }
 

--- a/testcases/kernel/syscalls/epoll_wait/epoll_wait02.c
+++ b/testcases/kernel/syscalls/epoll_wait/epoll_wait02.c
@@ -50,7 +50,7 @@ static void setup(void)
 	epevs[0].data.fd = fds[0];
 
 	if (epoll_ctl(epfd, EPOLL_CTL_ADD, fds[0], &epevs[0]))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static void cleanup(void)

--- a/testcases/kernel/syscalls/epoll_wait/epoll_wait03.c
+++ b/testcases/kernel/syscalls/epoll_wait/epoll_wait03.c
@@ -57,7 +57,7 @@ static void setup(void)
 	epevs[0].data.fd = fds[1];
 
 	if (epoll_ctl(epfd, EPOLL_CTL_ADD, fds[1], &epevs[0]))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static void verify_epoll_wait(unsigned int n)

--- a/testcases/kernel/syscalls/epoll_wait/epoll_wait04.c
+++ b/testcases/kernel/syscalls/epoll_wait/epoll_wait04.c
@@ -49,7 +49,7 @@ static void setup(void)
 	epevs[0].data.fd = fds[0];
 
 	if (epoll_ctl(epfd, EPOLL_CTL_ADD, fds[0], &epevs[0]))
-		tst_brk(TBROK | TERRNO, "epoll_clt(..., EPOLL_CTL_ADD, ...)");
+		tst_brk(TBROK | TERRNO, "epoll_ctl(..., EPOLL_CTL_ADD, ...)");
 }
 
 static void cleanup(void)


### PR DESCRIPTION
The result of epoll_ctl has a typo, "epoll_ctl" -> "epoll_clt"

@mrchapp @tdmackey @rossburton @hwoarang 

<!--
* Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/
There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).
LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.ozlabs.org/project/ltp/list/.

* Commits should be signed: Signed-off-by: Your Name <me@example.org>, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

* Commit message should be meaningful, following common style
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes
https://cbea.ms/git-commit/

* New code should follow Linux kernel coding style, see
https://www.kernel.org/doc/html/latest/process/coding-style.html.
You can run 'make check' or 'make check-foo' in the folder with modified code to check style and common errors.

* For more tips check
https://github.com/linux-test-project/ltp/wiki/Maintainer-Patch-Review-Checklist
https://github.com/linux-test-project/ltp/wiki/Test-Writing-Guidelines
https://github.com/linux-test-project/ltp/wiki/C-Test-API
https://github.com/linux-test-project/ltp/wiki/Shell-Test-API
https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial
-->
