### PR TITLE
openposix: pthread_rwlock_unlock: Add support for NuttX

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
@@ -31,7 +31,7 @@ int main(void)
 	static pthread_rwlock_t rwlock;
 	int rc;
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__NuttX__)
 	printf("Unlocking uninitialized rwlock is undefined on Linux\n");
 	return PTS_UNSUPPORTED;
 #endif


### PR DESCRIPTION
Make the test is unsupported on NuttX too.

Signed-off-by: Shoukui Zhang <zhangshoukui@xiaomi.com>