### PR TITLE
openposix: Use #ifdef instead of #if for __linux__

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
@@ -15,7 +15,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#if __linux__
+#ifdef __linux__
 #include <features.h>
 #endif
 #include <semaphore.h>


### PR DESCRIPTION
to fix __linux__ macro using error case

Signed-off-by: Brennan Ashton <bashton@brennanashton.com>