### PR TITLE
open_posix: modified ltp,rwlock need init

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c
@@ -23,7 +23,7 @@
 int main(void)
 {
 
-	static pthread_rwlock_t rwlock;
+	static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
 	int rc;
 
 	/* Call without initializing rwlock */


### PR DESCRIPTION
open_posix: the rwlock need to init, to add init procedure to the rwlock before use

Signed-off-by: anjiahao <anjiahao@xiaomi.com>