### PR TITLE
open_posix: modify code for fdcheck check compatibility

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_close/3-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_close/3-3.c
@@ -23,7 +23,7 @@
 int main(void)
 {
 	/* Use some arbitrary but high number for the descriptor.  */
-	if (mq_close((mqd_t) 274) != -1) {
+	if (mq_close((mqd_t) (OPEN_MAX - 1)) != -1) {
 		printf("mq_close() did not return -1 on invalid descriptor\n");
 		printf("Test FAILED\n");
 		return PTS_FAIL;


### PR DESCRIPTION
open_posix: the origin implementation cannot pass the fdcheck test, using the OPEN_MAX to control can help compatible with the fdcheck test

Signed-off-by: hujun5 <hujun5@xiaomi.com>