### PR TITLE
open_posix: Re-init static variable to avoid errors during multiple runs

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c
@@ -101,6 +101,9 @@ int main(void)
 	struct sigaction act;
 	pthread_mutexattr_t ma;
 
+	waken_num = 0;
+	start_num = 0;
+
 	if (pthread_mutexattr_init(&ma) != 0) {
 		fprintf(stderr, "Fail to initialize mutex attribute\n");
 		return PTS_UNRESOLVED;

--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c
@@ -79,6 +79,9 @@ int main(void)
 	int i, rc;
 	struct sigaction act;
 
+	waken_num = 0;
+	start_num = 0;
+
 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
 		fprintf(stderr, "Fail to initialize mutex\n");
 		return PTS_UNRESOLVED;


### PR DESCRIPTION
open_posix: the static variables need to re-init before running again, thus to aovid report error with running multiple times

Signed-off-by: Huang Qi <huangqi3@xiaomi.com>