### PR TITLE
ltp: fix the testcase build warning

### DIFF
--- a/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
+++ b/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
@@ -399,7 +399,7 @@ int main(int argc, char *argv[])
  * The function returns 0 when r1 is the best for all cases (latency is constant) and !0 otherwise.
  */
 
-static struct row {
+struct row {
 	long X;			/* the X values -- copied from function argument */
 	long Y_o;		/* the Y values -- copied from function argument */
 	long Y_c;		/* the Y values -- copied from function argument */


### PR DESCRIPTION
the detailed build warning are :
ltp/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c:415:1: warning: useless storage class specifier in empty declaration
  415 | };
      | ^
