### PR TITLE
fix mmap/mremap address not aligned to MMAP_GRANULARITY

### DIFF
--- a/testcases/kernel/mem/hugetlb/hugemmap/hugemmap13.c
+++ b/testcases/kernel/mem/hugetlb/hugemmap/hugemmap13.c
@@ -21,6 +21,7 @@
 #include <limits.h>
 #include <sys/param.h>
 #include <sys/types.h>
+#include <lapi/mmap.h>
 
 #include "hugetlb.h"
 
@@ -62,15 +63,15 @@ static void run_test(void)
 	memset(p, 0, hpage_size);
 
 	/* Test just below 4GB to check for off-by-one errors */
-	lowaddr = FOURGB - page_size;
-	q = mmap((void *)lowaddr, page_size, PROT_READ|PROT_WRITE,
+	lowaddr = FOURGB - MMAP_GRANULARITY;
+	q = mmap((void *)lowaddr, MMAP_GRANULARITY, PROT_READ|PROT_WRITE,
 		 MAP_SHARED|MAP_FIXED|MAP_ANONYMOUS, 0, 0);
 	if (q == MAP_FAILED) {
-		below_start = FOURGB - page_size;
+		below_start = FOURGB - MMAP_GRANULARITY;
 		above_end = FOURGB;
 
 		if (range_is_mapped(below_start, above_end) == 1) {
-			tst_res(TINFO|TERRNO, "region (4G-page)-4G is not free & "
+			tst_res(TINFO|TERRNO, "region (4G-MMAP_GRANULARITY)-4G is not free & "
 					"mmap() failed expected");
 			tst_res(TPASS, "Successful but inconclusive");
 		} else


### PR DESCRIPTION
when we do mmap(MAP_SHARED),mmaped address should be aligned to MMAP_GRANULARITY,otherwise error will returned and the test will fail.
mremap and remap_file_pages should also follow this rule.

<!--
* Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/
There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).
LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.ozlabs.org/project/ltp/list/.

* Commits should be signed: Signed-off-by: Your Name <me@example.org>, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

* Commit message should be meaningful, following common style
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes
https://cbea.ms/git-commit/

* New code should follow Linux kernel coding style, see
https://www.kernel.org/doc/html/latest/process/coding-style.html.
You can run 'make check' or 'make check-foo' in the folder with modified code to check style and common errors.

* For more tips check
https://github.com/linux-test-project/ltp/wiki/Maintainer-Patch-Review-Checklist
https://github.com/linux-test-project/ltp/wiki/Test-Writing-Guidelines
https://github.com/linux-test-project/ltp/wiki/C-Test-API
https://github.com/linux-test-project/ltp/wiki/Shell-Test-API
https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial
-->
