### PR TITLE
Refactor sched_yield01 with new API

### DIFF
--- a/testcases/kernel/syscalls/sched_yield/sched_yield01.c
+++ b/testcases/kernel/syscalls/sched_yield/sched_yield01.c
@@ -1,101 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
- *
- *   Copyright (c) International Business Machines  Corp., 2001
- *
- *   This program is free software;  you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation; either version 2 of the License, or
- *   (at your option) any later version.
- *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
- *   the GNU General Public License for more details.
- *
- *   You should have received a copy of the GNU General Public License
- *   along with this program;  if not, write to the Free Software
- *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * Copyright (c) International Business Machines  Corp., 2001
+ * Copyright (C) 2024 SUSE LLC Andrea Manzini <andrea.manzini@suse.com>
  */
 
-/*
- * NAME
- *	sched_yield01.C
+/*\
+ * [Description]
  *
- * DESCRIPTION
- *	Testcase to check that sched_yield returns correct values.
- *
- * ALGORITHM
- *	Call sched_yield(), check its return value. If it is 0, then pass,
- *	otherwise fail with proper errno!
- *
- * USAGE:  <for command-line>
- * sched_yield01 [-c n] [-i n] [-I x] [-P x] [-t]
- *     where,  -c n : Run n copies concurrently.
- *             -i n : Execute test n times.
- *             -I x : Execute test for x seconds.
- *             -P x : Pause for x seconds between iterations.
- *             -t   : Turn on syscall timing.
- *
- * HISTORY
- *	07/2001 Ported by Wayne Boyer
- *
- * RESTRICTIONS
- *	None
+ * Testcase to check that sched_yield returns correct values.
  */
-#include <stdio.h>
+
 #include <sched.h>
-#include <errno.h>
-#include "test.h"
+#include "tst_test.h"
 
-char *TCID = "sched_yield01";
-int TST_TOTAL = 1;
-
-void setup(void);
-void cleanup(void);
-
-int main(int ac, char **av)
+static void run(void)
 {
-	int lc;
-
-	tst_parse_opts(ac, av, NULL, NULL);
-
-	setup();
-
-	for (lc = 0; TEST_LOOPING(lc); lc++) {
-
-		/* reset tst_count in case we are looping */
-		tst_count = 0;
-
-		TEST(sched_yield());
-
-		if (TEST_RETURN != 0) {
-			tst_resm(TFAIL, "call failed - errno %d : %s",
-				 TEST_ERRNO, strerror(TEST_ERRNO));
-		} else {
-			tst_resm(TPASS, "sched_yield() call succeeded");
-		}
-	}
-	cleanup();
-	tst_exit();
-
+	TST_EXP_PASS(sched_yield());
 }
 
-/*
- * setup() - performs all ONE TIME setup for this test.
- */
-void setup(void)
-{
-
-	tst_sig(NOFORK, DEF_HANDLER, cleanup);
-
-	TEST_PAUSE;
-}
-
-/*
- * cleanup() - performs all ONE TIME cleanup for this test at
- *	       completion or premature exit.
- */
-void cleanup(void)
-{
-
-}
+static struct tst_test test = {
+	.test_all = run,
+};


### PR DESCRIPTION
Very simple refactoring.

Note frome the man page:
```
RETURN VALUE
       On success, sched_yield() returns 0.  On error, -1 is returned, and errno is set to indicate the error.

ERRORS
       In the Linux implementation, sched_yield() always succeeds.
```
So this test is basically an invariant assertion check. 
