### PR TITLE
Refactor open09.c with new LTP API

### DIFF
--- a/testcases/kernel/syscalls/open/open09.c
+++ b/testcases/kernel/syscalls/open/open09.c
@@ -1,109 +1,50 @@
-/*
- *   Copyright (c) International Business Machines  Corp., 2002
- *   Copyright (c) 2013 Wanlong Gao <gaowanlong@cn.fujitsu.com>
- *
- *   This program is free software;  you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation; either version 2 of the License, or
- *   (at your option) any later version.
- *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
- *   the GNU General Public License for more details.
- *
- *   You should have received a copy of the GNU General Public License
- *   along with this program;  if not, write to the Free Software
- *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 /*
- * Description:
- *	1. open an O_WRONLY file, test if read failed.
- *	2. open an O_RDONLY file, test if write failed.
+ * Copyright (c) International Business Machines  Corp., 2002
+ * Copyright (c) 2013 Wanlong Gao <gaowanlong@cn.fujitsu.com>
+ * Copyright (C) 2024 SUSE LLC Andrea Manzini <andrea.manzini@suse.com>
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <stdio.h>
-#include <fcntl.h>
-#include "test.h"
+/*\
+ * [Description]
+ * This test verifies that a file opened with O_RDONLY can't be writable
+ * and it verifies that a file opened with O_WRONLY can't be readable.
+ */
 
-char *TCID = "open09";
-int TST_TOTAL = 2;
+#include "tst_test.h"
 
-#define PASSED 1
-#define FAILED 0
-
-static char tempfile[40] = "";
-
-static void setup(void);
-static void cleanup(void);
-
-int main(int ac, char *av[])
-{
-	int fildes;
-	int ret = 0;
-	char pbuf[BUFSIZ];
-
-	int lc;
-
-	tst_parse_opts(ac, av, NULL, NULL);
-
-	setup();
-
-	for (lc = 0; TEST_LOOPING(lc); lc++) {
-
-		fildes = open(tempfile, O_WRONLY);
-		if (fildes == -1)
-			tst_brkm(TFAIL, cleanup, "\t\t\topen failed");
-
-		ret = read(fildes, pbuf, 1);
-		if (ret != -1)
-			tst_resm(TFAIL, "read should not succeed");
-		else
-			tst_resm(TPASS, "Test passed in O_WRONLY.");
-
-		close(fildes);
-
-		fildes = open(tempfile, O_RDONLY);
-		if (fildes == -1) {
-			tst_resm(TFAIL, "\t\t\topen failed");
-		} else {
-			ret = write(fildes, pbuf, 1);
-			if (ret != -1)
-				tst_resm(TFAIL, "write should not succeed");
-			else
-				tst_resm(TPASS, "Test passed in O_RDONLY.");
-		}
-		close(fildes);
-	}
-
-	cleanup();
-	tst_exit();
-}
+#define TEMPFILE "testfile"
 
 static void setup(void)
 {
-	int fildes;
-
-	tst_sig(NOFORK, DEF_HANDLER, cleanup);
-	TEST_PAUSE;
-	tst_tmpdir();
-
-	sprintf(tempfile, "open09.%d", getpid());
-
-	fildes = creat(tempfile, 0600);
-	if (fildes == -1) {
-		tst_brkm(TBROK, cleanup, "\t\t\tcan't create '%s'",
-			 tempfile);
-	} else {
-		close(fildes);
-	}
+	SAFE_CREAT(TEMPFILE, 0600);
 }
 
 static void cleanup(void)
 {
-	unlink(tempfile);
-	tst_rmdir();
+	SAFE_UNLINK(TEMPFILE);
 }
+
+static void verify_open(unsigned int nr)
+{
+	char pbuf[BUFSIZ];
+	int fd = 0;
+
+	if (nr == 0) {
+		fd = SAFE_OPEN(TEMPFILE, O_RDONLY);
+		TST_EXP_FAIL(write(fd, pbuf, 1), EBADF);
+	} else {
+		fd = SAFE_OPEN(TEMPFILE, O_WRONLY);
+		TST_EXP_FAIL(read(fd, pbuf, 1), EBADF);
+	}
+	SAFE_CLOSE(fd);
+}
+
+static struct tst_test test = {
+	.setup = setup,
+	.cleanup = cleanup,
+	.test = verify_open,
+	.tcnt = 2,
+	.needs_tmpdir = 1,
+};


### PR DESCRIPTION
Refactoring with new LTP API.

The original test tries to write on a O_RDONLY file, and read on a O_WRONLY file, expecting failures. 

I could not came up with a more concise / elegant solution so improvement suggestions are welcome.

