### PR TITLE
getpeername01 : refactor with new LTP API

### DIFF
--- a/testcases/kernel/syscalls/getpeername/getpeername01.c
+++ b/testcases/kernel/syscalls/getpeername/getpeername01.c
@@ -1,178 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
- *
- *   Copyright (c) International Business Machines  Corp., 2001
+ * Copyright (c) International Business Machines  Corp., 2001
  *   07/2001 Ported by Wayne Boyer
+ * Copyright (C) 2024 SUSE LLC Andrea Manzini <andrea.manzini@suse.com>
  *
- *   This program is free software;  you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation; either version 2 of the License, or
- *   (at your option) any later version.
- *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
- *   the GNU General Public License for more details.
- *
- *   You should have received a copy of the GNU General Public License
- *   along with this program;  if not, write to the Free Software Foundation,
- *   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/*
- *  Verify that getpeername() returns the proper errno for various failure cases
+/*\
+ * [Description]
+ * Verify that getpeername() returns the proper errno for various failure cases:
+ * - EBADF on invalid address.
+ * - ENOTSOCK on socket opened on /dev/null.
+ * - ENOTCONN on socket not connected.
+ * - EINVAL on negative addrlen.
+ * - EFAULT on invalid addr/addrlen pointers.
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/signal.h>
-#include <sys/ioctl.h>
-#include <netinet/in.h>
-
-#include "test.h"
-#include "safe_macros.h"
+#include "tst_test.h"
 
 static struct sockaddr_in server_addr;
 static struct sockaddr_in fsin1;
 static socklen_t sinlen;
 static socklen_t invalid_sinlen = -1;
 static int sv[2];
+static int sockfd = -1;
 
-static void setup(void);
-static void setup2(int);
-static void setup3(int);
-static void setup4(int);
-static void cleanup(void);
-static void cleanup2(int);
-static void cleanup4(int);
+static void setup_fd_file(void)
+{
+	sockfd = SAFE_OPEN("/dev/null", O_WRONLY, 0666);
+}
 
-struct test_case_t {
-	int sockfd;
+static void setup_fd_stream(void)
+{
+	sockfd = SAFE_SOCKET(PF_INET, SOCK_STREAM, 0);
+	SAFE_BIND(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+}
+
+static void cleanup_fd(void)
+{
+	if (sockfd)
+		SAFE_CLOSE(sockfd);
+}
+
+static void setup_pair(void)
+{
+	SAFE_SOCKETPAIR(PF_UNIX, SOCK_STREAM, 0, sv);
+	sockfd = sv[0];
+}
+
+static void cleanup_pair(void)
+{
+	if (sv[0])
+		SAFE_CLOSE(sv[0]);
+	if (sv[1])
+		SAFE_CLOSE(sv[1]);
+}
+
+static struct test_case {
 	struct sockaddr *sockaddr;
 	socklen_t *addrlen;
-	int expretval;
 	int experrno;
-	void (*setup) (int);
-	void (*cleanup) (int);
-	char *name;
+	void (*case_setup)(void);
+	void (*case_cleanup)(void);
 } test_cases[] = {
-	{-1, (struct sockaddr *)&fsin1, &sinlen, -1, EBADF, NULL, NULL,
-	 "EBADF"},
-	{-1, (struct sockaddr *)&fsin1, &sinlen, -1, ENOTSOCK, setup2, cleanup2,
-	 "ENOTSOCK"},
-	{-1, (struct sockaddr *)&fsin1, &sinlen, -1, ENOTCONN, setup3, cleanup2,
-	 "ENOTCONN"},
-	{-1, (struct sockaddr *)&fsin1, &invalid_sinlen, -1, EINVAL, setup4,
-	 cleanup4, "EINVAL"},
-#ifndef UCLINUX
-	{-1, (struct sockaddr *)-1, &sinlen, -1, EFAULT, setup4, cleanup4,
-	 "EFAULT"},
-	{-1, (struct sockaddr *)&fsin1, NULL, -1, EFAULT, setup4,
-	 cleanup4, "EFAULT"},
-	{-1, (struct sockaddr *)&fsin1, (socklen_t *)1, -1, EFAULT, setup4,
-	 cleanup4, "EFAULT"},
-#endif
+	{.addrlen = &sinlen, .experrno = EBADF},
+	{.addrlen = &sinlen, .experrno = ENOTSOCK, .case_setup = setup_fd_file, .case_cleanup = cleanup_fd },
+	{.addrlen = &sinlen, .experrno = ENOTCONN, .case_setup = setup_fd_stream, .case_cleanup = cleanup_fd },
+	{.addrlen = &invalid_sinlen, .experrno = EINVAL, .case_setup = setup_pair, .case_cleanup = cleanup_pair},
+	{.sockaddr = (struct sockaddr *) -1, .addrlen = &sinlen, .experrno = EFAULT, .case_setup = setup_pair, .case_cleanup = cleanup_pair},
+	{.experrno = EFAULT, .case_setup = setup_pair, .case_cleanup = cleanup_pair},
+	{.addrlen = (socklen_t *) 1, .experrno = EFAULT, .case_setup = setup_pair, .case_cleanup = cleanup_pair },
 };
 
-char *TCID = "getpeername01";
-int TST_TOTAL = ARRAY_SIZE(test_cases);
-
-int main(int argc, char *argv[])
+static void verify_getpeername(unsigned int nr)
 {
-	int lc;
-	int i;
+	struct test_case *tc = &test_cases[nr];
 
-	tst_parse_opts(argc, argv, NULL, NULL);
+	if (tc->case_setup != NULL)
+		tc->case_setup();
 
-	setup();
+	if (!tc->sockaddr)
+		tc->sockaddr = (struct sockaddr *)&fsin1;
 
-	for (lc = 0; TEST_LOOPING(lc); ++lc) {
+	TST_EXP_FAIL(getpeername(sockfd, tc->sockaddr, tc->addrlen), tc->experrno);
 
-		tst_count = 0;
-
-		for (i = 0; i < TST_TOTAL; ++i) {
-
-			if (test_cases[i].setup != NULL)
-				test_cases[i].setup(i);
-
-			TEST(getpeername(test_cases[i].sockfd,
-					 test_cases[i].sockaddr,
-					 test_cases[i].addrlen));
-
-			if (TEST_RETURN == test_cases[i].expretval &&
-			    TEST_ERRNO == test_cases[i].experrno) {
-				tst_resm(TPASS,
-					 "test getpeername() %s successful",
-					 test_cases[i].name);
-			} else {
-				tst_resm(TFAIL,
-					 "test getpeername() %s failed; "
-					 "returned %ld (expected %d), errno %d "
-					 "(expected %d)", test_cases[i].name,
-					 TEST_RETURN, test_cases[i].expretval,
-					 TEST_ERRNO, test_cases[i].experrno);
-			}
-
-			if (test_cases[i].cleanup != NULL)
-				test_cases[i].cleanup(i);
-		}
-	}
-
-	cleanup();
-
-	tst_exit();
+	if (tc->case_cleanup != NULL)
+		tc->case_cleanup();
 }
 
 static void setup(void)
 {
-	TEST_PAUSE;
-
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_port = 0;
 	server_addr.sin_addr.s_addr = INADDR_ANY;
-
 	sinlen = sizeof(fsin1);
 }
 
-static void cleanup(void)
-{
-}
-
-static void setup2(int i)
-{
-	test_cases[i].sockfd = SAFE_OPEN(cleanup, "/dev/null", O_WRONLY, 0666);
-}
-
-static void setup3(int i)
-{
-	test_cases[i].sockfd = socket(PF_INET, SOCK_STREAM, 0);
-	if (test_cases[i].sockfd < 0) {
-		tst_brkm(TBROK | TERRNO, cleanup,
-			 "socket setup failed for getpeername test %d", i);
-	}
-	SAFE_BIND(cleanup, test_cases[i].sockfd,
-		  (struct sockaddr *)&server_addr, sizeof(server_addr));
-}
-
-static void setup4(int i)
-{
-	if (socketpair(PF_UNIX, SOCK_STREAM, 0, sv) < 0) {
-		tst_brkm(TBROK | TERRNO, cleanup,
-			 "socketpair failed for getpeername test %d", i);
-	}
-	test_cases[i].sockfd = sv[0];
-}
-
-static void cleanup2(int i)
-{
-	SAFE_CLOSE(cleanup, test_cases[i].sockfd);
-}
-
-static void cleanup4(int i)
-{
-	SAFE_CLOSE(cleanup, sv[0]);
-	SAFE_CLOSE(cleanup, sv[1]);
-}
+static struct tst_test test = {
+	.setup = setup,
+	.test = verify_getpeername,
+	.tcnt = ARRAY_SIZE(test_cases),
+};


### PR DESCRIPTION
This test verifies that getpeername() returns the proper error for various failure cases.

refactored using new API, SAFE_* macros and renaming helper functions for a clearer code.

