### PR TITLE
netns_lib.sh: using ping -6 instead of ping6 to fix ipv6 netns test fails

### DIFF
--- a/testcases/kernel/containers/netns/netns_lib.sh
+++ b/testcases/kernel/containers/netns/netns_lib.sh
@@ -82,11 +82,11 @@ netns_setup()
 	if [ "$TST_IPV6" ]; then
 		IFCONF_IN6_ARG="inet6 add"
 		NETMASK=64
+		tping="ping -6"
 	else
 		NETMASK=24
+		tping=ping
 	fi
-
-	tping=ping$TST_IPV6
 
 	netns_set_ip
 


### PR DESCRIPTION
Currently, on some distribution, the ping6 using GNU inetutils, it doesn't support "-I" option, that cause IPv6 netns related test case fails.

If building an iputils from source code, it doesn't generate ping6 by default, from its documents we can learn that it can use ping -6 to ping an IPv6 address.

