### PR TITLE
getsockopt01: refactor with new LTP API

### DIFF
--- a/testcases/kernel/syscalls/getsockopt/getsockopt01.c
+++ b/testcases/kernel/syscalls/getsockopt/getsockopt01.c
@@ -1,208 +1,87 @@
-/*
- *
- *   Copyright (c) International Business Machines  Corp., 2001
- *
- *   This program is free software;  you can redistribute it and/or modify
- *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation; either version 2 of the License, or
- *   (at your option) any later version.
- *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
- *   the GNU General Public License for more details.
- *
- *   You should have received a copy of the GNU General Public License
- *   along with this program;  if not, write to the Free Software
- *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 /*
- * Test Name: getsockopt01
- *
- * Test Description:
- *  Verify that getsockopt() returns the proper errno for various failure cases
- *
- * Usage:  <for command-line>
- *  getsockopt01 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
- *     where,  -c n : Run n copies concurrently.
- *             -e   : Turn on errno logging.
- *	       -i n : Execute test n times.
- *	       -I x : Execute test for x seconds.
- *	       -P x : Pause for x seconds between iterations.
- *	       -t   : Turn on syscall timing.
- *
- * HISTORY
- *	07/2001 Ported by Wayne Boyer
- *
- * RESTRICTIONS:
- *  None.
+ * Copyright (c) International Business Machines  Corp., 2001
+ * 07/2001 Ported by Wayne Boyer
+ * Copyright (C) 2024 SUSE LLC Andrea Manzini <andrea.manzini@suse.com>
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <errno.h>
-#include <fcntl.h>
+/*\
+ * [Description]
+ * Verify that getsockopt() returns the proper errno for various failure cases:
+ *
+ * - EBADF on a not open file
+ * - ENOTSOCK on a file descriptor not linked to a socket
+ * - EFAULT on invalid address of value or length
+ * - EOPNOTSUPP on invalid option name or protocol
+ */
 
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/signal.h>
-#include <sys/ioctl.h>
+#include "tst_test.h"
 
-#include <netinet/in.h>
+static int sock_fake, sock_null, sock_bind;
+static struct sockaddr_in sin0;
+static int sinlen;
+static int optval;
+static socklen_t optlen;
 
-#include "test.h"
-#include "safe_macros.h"
-
-char *TCID = "getsockopt01";
-int testno;
-
-int s;				/* socket descriptor */
-struct sockaddr_in sin0, fsin1;
-int sinlen;
-int optval;
-socklen_t optlen;
-
-void setup(void), setup0(void), setup1(void),
-cleanup(void), cleanup0(void), cleanup1(void);
-
-struct test_case_t {		/* test case structure */
-	int domain;		/* PF_INET, PF_UNIX, ... */
-	int type;		/* SOCK_STREAM, SOCK_DGRAM ... */
-	int proto;		/* protocol number (usually 0 = default) */
-	int level;		/* IPPROTO_* */
+static struct test_case {
+	int *sockfd;
+	int level;
 	int optname;
 	void *optval;
 	socklen_t *optlen;
-	struct sockaddr *sin;
-	int salen;
-	int retval;		/* syscall return value */
-	int experrno;		/* expected errno */
-	void (*setup) (void);
-	void (*cleanup) (void);
+	int experrno;
 	char *desc;
-} tdat[] = {
-	{
-	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval,
-		    &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
-		    -1, EBADF, setup0, cleanup0, "bad file descriptor"}
-	, {
-	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval,
-		    &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
-		    -1, ENOTSOCK, setup0, cleanup0, "bad file descriptor"}
-	,
-#ifndef UCLINUX
-	{
-	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, 0, &optlen,
-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
-		    EFAULT, setup1, cleanup1, "invalid option buffer"}
-	, {
-	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,
-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
-		    EFAULT, setup1, cleanup1, "invalid optlen"}
-	,
-#endif /* UCLINUX */
-	{
-	PF_INET, SOCK_STREAM, 0, 500, SO_OOBINLINE, &optval, &optlen,
-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
-		    EOPNOTSUPP, setup1, cleanup1, "invalid level"}
-	, {
-	PF_INET, SOCK_STREAM, 0, IPPROTO_UDP, SO_OOBINLINE, &optval,
-		    &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
-		    -1, EOPNOTSUPP, setup1, cleanup1, "invalid option name"}
-	, {
-	PF_INET, SOCK_STREAM, 0, IPPROTO_UDP, SO_OOBINLINE, &optval,
-		    &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
-		    -1, EOPNOTSUPP, setup1, cleanup1,
-		    "invalid option name (UDP)"}
-	, {
-	PF_INET, SOCK_STREAM, 0, IPPROTO_IP, -1, &optval, &optlen,
-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
-		    ENOPROTOOPT, setup1, cleanup1, "invalid option name (IP)"}
-	, {
-	PF_INET, SOCK_STREAM, 0, IPPROTO_TCP, -1, &optval, &optlen,
-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
-		    ENOPROTOOPT, setup1, cleanup1, "invalid option name (TCP)"}
-,};
+} tcases[] = {
+	{.sockfd = &sock_fake, .level = SOL_SOCKET, .optname = SO_OOBINLINE, .optval = &optval,
+	.optlen = &optlen, .experrno = EBADF, .desc = "bad file descriptor"},
 
-int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+	{.sockfd = &sock_null, .level = SOL_SOCKET, .optname = SO_OOBINLINE, .optval = &optval,
+	.optlen = &optlen, .experrno = ENOTSOCK, .desc = "bad file descriptor"},
 
-int main(int argc, char *argv[])
+	{.sockfd = &sock_bind, .level = SOL_SOCKET, .optname = SO_OOBINLINE, .optval = 0,
+	.optlen = &optlen, .experrno = EFAULT, .desc = "invalid option buffer"},
+
+	{.sockfd = &sock_bind, .level = SOL_SOCKET, .optname = SO_OOBINLINE, .optval = &optval,
+	.optlen = 0, .experrno = EFAULT, .desc = "invalid optlen"},
+
+	{.sockfd = &sock_bind, .level = 500, .optname = SO_OOBINLINE, .optval = &optval,
+	.optlen = &optlen, .experrno = EOPNOTSUPP, .desc = "invalid level"},
+
+	{.sockfd = &sock_bind, .level = IPPROTO_UDP, .optname = SO_OOBINLINE, .optval = &optval,
+	.optlen = &optlen, .experrno = EOPNOTSUPP, .desc = "not supported option name (UDP)"},
+
+	{.sockfd = &sock_bind, .level = IPPROTO_IP, .optname = -1, .optval = &optval,
+	.optlen = &optlen, .experrno = ENOPROTOOPT, .desc =  "invalid option name (IP)"},
+
+	{.sockfd = &sock_bind, .level = IPPROTO_TCP, .optname = -1,	.optval = &optval,
+	.optlen = &optlen, .experrno = ENOPROTOOPT, .desc = "invalid option name (TCP)"}
+};
+
+
+static void check_getsockopt(unsigned int nr)
 {
-	int lc;
+	struct test_case *tc = &tcases[nr];
 
-	tst_parse_opts(argc, argv, NULL, NULL);
-
-	setup();
-
-	for (lc = 0; TEST_LOOPING(lc); ++lc) {
-		tst_count = 0;
-		for (testno = 0; testno < TST_TOTAL; ++testno) {
-			tdat[testno].setup();
-
-			TEST(getsockopt(s, tdat[testno].level,
-					tdat[testno].optname,
-					tdat[testno].optval,
-					tdat[testno].optlen));
-			if (TEST_RETURN != tdat[testno].retval ||
-			    (TEST_RETURN < 0 &&
-			     TEST_ERRNO != tdat[testno].experrno)) {
-				tst_resm(TFAIL, "%s ; returned"
-					 " %ld (expected %d), errno %d (expected"
-					 " %d)", tdat[testno].desc,
-					 TEST_RETURN, tdat[testno].retval,
-					 TEST_ERRNO, tdat[testno].experrno);
-			} else {
-				tst_resm(TPASS, "%s successful",
-					 tdat[testno].desc);
-			}
-			tdat[testno].cleanup();
-		}
-	}
-	cleanup();
-
-	tst_exit();
+	TST_EXP_FAIL(getsockopt(*(tc->sockfd), tc->level, tc->optname, tc->optval, tc->optlen),
+		tc->experrno, "%s", tc->desc);
 }
 
-void setup(void)
+static void setup(void)
 {
-	TEST_PAUSE;
-
-	/* initialize local sockaddr */
 	sin0.sin_family = AF_INET;
 	sin0.sin_port = 0;
 	sin0.sin_addr.s_addr = INADDR_ANY;
-}
-
-void cleanup(void)
-{
-}
-
-void setup0(void)
-{
-	if (tdat[testno].experrno == EBADF)
-		s = 400;	/* anything not an open file */
-	else if ((s = open("/dev/null", O_WRONLY)) == -1)
-		tst_brkm(TBROK, cleanup, "error opening /dev/null - "
-			 "errno: %s", strerror(errno));
-}
-
-void cleanup0(void)
-{
-	s = -1;
-}
-
-void setup1(void)
-{
-	s = SAFE_SOCKET(cleanup, tdat[testno].domain, tdat[testno].type,
-			tdat[testno].proto);
-	SAFE_BIND(cleanup, s, (struct sockaddr *)&sin0, sizeof(sin0));
-	sinlen = sizeof(fsin1);
+	sock_fake = 400;
+	sock_null = SAFE_OPEN("/dev/null", O_WRONLY);
+	sock_bind = SAFE_SOCKET(PF_INET, SOCK_STREAM, 0);
+	SAFE_BIND(sock_bind, (struct sockaddr *)&sin0, sizeof(sin0));
+	sinlen = sizeof(sin0);
 	optlen = sizeof(optval);
 }
 
-void cleanup1(void)
-{
-	(void)close(s);
-	s = -1;
-}
+static struct tst_test test = {
+	.setup = setup,
+	.test = check_getsockopt,
+	.tcnt = ARRAY_SIZE(tcases),
+};


### PR DESCRIPTION
Refactoring of this test that verifies getsockopt() returning the proper errno for various failure cases