### PR TITLE
getrandom: Fix missing sys/random header on centos 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_CHECK_HEADERS_ONCE([ \
     sys/inotify.h \
     sys/pidfd.h
     sys/prctl.h \
+    sys/random.h \
     sys/shm.h \
     sys/timerfd.h \
     sys/ustat.h \

--- a/testcases/kernel/syscalls/getrandom/getrandom05.c
+++ b/testcases/kernel/syscalls/getrandom/getrandom05.c
@@ -13,7 +13,11 @@
  * - EINVAL when flag is invalid
  */
 
+#ifdef HAVE_SYS_RANDOM_H
 #include <sys/random.h>
+#else
+#include <sys/syscall.h>
+#endif
 #include "tst_test.h"
 
 static char buff_efault[64];
@@ -30,6 +34,13 @@ static struct test_case_t {
 		"buf address is outside the accessible address space"},
 	{buff_einval, sizeof(buff_einval), -1, EINVAL, "flag is invalid"},
 };
+
+#ifndef HAVE_SYS_RANDOM_H
+ssize_t getrandom(void *buffer, size_t length, unsigned int flags)
+{
+	return syscall(SYS_getrandom, buffer, length, flags);
+}
+#endif
 
 static void verify_getrandom(unsigned int i)
 {


### PR DESCRIPTION
Some old distros like centos 7 don't have glibc with "sys/random.h". Add ac check for this header file and implement `getrandom()` for getrandom05 when the file is missing.

cc @xuyang0410 