### PR TITLE
scenario_groups/default: remove io, filecaps and cap_bounds

### DIFF
--- a/scenario_groups/default
+++ b/scenario_groups/default
@@ -2,7 +2,6 @@ syscalls
 fs
 fs_perms_simple
 dio
-io
 mm
 ipc
 irq
@@ -13,8 +12,6 @@ pty
 containers
 fs_bind
 controllers
-filecaps
-cap_bounds
 fcntl-locktests
 power_management_tests
 hugetlb


### PR DESCRIPTION
runtest/io was removed in 0d9dc994e
runtest/filecaps and cap_bounds was removed in 071727828

Fixes: 0d9dc994e ("runtest: Move io content to ltp-aiodio.part4")
Fixes: 071727828 ("runtest: Move capability related tests to new capability")
Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>
