### PR TITLE
ebizzy: Fix a typo in README

### DIFF
--- a/utils/benchmark/ebizzy-0.3/README
+++ b/utils/benchmark/ebizzy-0.3/README
@@ -11,7 +11,7 @@ Compiling
 ---------
 
 First configure ebizzy for your platform by typing "./configure".
-Currently Linux and Solaris anre supported.  Then type "make".  The
+Currently Linux and Solaris are supported.  Then type "make".  The
 resulting binary will be named "ebizzy".
 
 Running


### PR DESCRIPTION
Fixed a spelling mistake in the README ("anre" to "are").

Signed-off-by: Madadi Vineeth Reddy <vineethr@linux.ibm.com>