### PR TITLE
printed character type is wrong

### DIFF
--- a/testcases/kernel/syscalls/close_range/close_range01.c
+++ b/testcases/kernel/syscalls/close_range/close_range01.c
@@ -48,7 +48,7 @@ static inline void do_close_range(unsigned int fd, unsigned int max_fd,
 			tst_brk(TCONF | TERRNO, "No CLOSE_RANGE_CLOEXEC");
 	}
 
-	tst_brk(TBROK | TERRNO, "close_range(%d, %d, %d)", fd, max_fd, flags);
+	tst_brk(TBROK | TERRNO, "close_range(%u, %u, %u)", fd, max_fd, flags);
 }
 
 static void setup(void)


### PR DESCRIPTION
close_range01: Fix printf format modifiers

Signed-off-by: Li Xiaosong <rj45usb@163.com>