### PR TITLE
cpuhotplug06.sh: use '-h' to identify top or htop

### DIFF
--- a/testcases/kernel/hotplug/cpu_hotplug/functional/cpuhotplug06.sh
+++ b/testcases/kernel/hotplug/cpu_hotplug/functional/cpuhotplug06.sh
@@ -53,7 +53,7 @@ if tst_virt_hyperv; then
 	tst_brkm TCONF "Microsoft Hyper-V detected, no support for CPU hotplug"
 fi
 
-if top -v | grep -q htop; then
+if top -h | grep -q htop; then
 	tst_brkm TCONF "htop is used instead of top (workaround: alias top='/path/to/real/top')"
 fi
 


### PR DESCRIPTION
'v' is invalid option for both top and htop in newer version. 
Replace it with 'h' to make it work in earlier and current version.



