### PR TITLE
Resolve #1200

### DIFF
--- a/testcases/kernel/syscalls/inotify/inotify11.c
+++ b/testcases/kernel/syscalls/inotify/inotify11.c
@@ -49,7 +49,7 @@ static void churn(void)
 	char path[10];
 	int i;
 
-	for (i = 0; i <= CHURN_FILES; ++i) {
+	for (i = 0; i < CHURN_FILES; ++i) {
 		snprintf(path, sizeof(path), "%d", i);
 		SAFE_FILE_PRINTF(path, "1");
 		SAFE_UNLINK(path);


### PR DESCRIPTION
(Migrates from `<=` to `<`, as [discussed](https://github.com/linux-test-project/ltp/issues/1200#issuecomment-2397423309).)