### PR TITLE
io_control01: fix the logic to identify the correct device

### DIFF
--- a/testcases/kernel/controllers/io/io_control01.c
+++ b/testcases/kernel/controllers/io/io_control01.c
@@ -64,11 +64,10 @@ static void run(void)
 		if (convs < 2)
 			continue;
 
-		tst_res(TINFO, "Found %u:%u in io.stat", dev_major, dev_minor);
-
-		if (start.mjr == dev_major || start.mnr == dev_minor)
+		if (start.mjr == dev_major && start.mnr == dev_minor) {
+			tst_res(TINFO, "Found %u:%u in io.stat", dev_major, dev_minor);
 			break;
-
+		}
 		line = strtok_r(NULL, "\n", &buf_ptr);
 	}
 


### PR DESCRIPTION
To select a device, both dev_major and dev_minor should match. However, following if condition passes if only one of them matches:
  if (start.mjr == dev_major || start.mnr == dev_minor)
Fix:
  if (start.mjr == dev_major && start.mnr == dev_minor)

Signed-off-by: Ajay Kaher <ajay.kaher@broadcom.com>
