### PR TITLE
Fix: handle filenames with spaces in kernbench script

### DIFF
--- a/utils/benchmark/kernbench-0.42/kernbench
+++ b/utils/benchmark/kernbench-0.42/kernbench
@@ -96,9 +96,8 @@ make clean > /dev/null 2>&1
 
 if [[ $fast_run -eq 0 ]] ; then
 	echo Caching kernel source in ram...
-	for i in `find -type f`
-	do
-		cat $i > /dev/null
+	find . -type f -print0 | while IFS= read -r -d '' i; do
+    		cat "$i" > /dev/null
 	done
 fi
 


### PR DESCRIPTION
Fix: handle filenames with spaces/newlines in kernbench source caching

This patch updates the loop used to cache the kernel source into RAM to handle filenames with spaces, newlines, and other special characters correctly.

Previously, the script used a `for` loop over backtick-evaluated `find`, which would break on filenames with spaces or unusual characters. This caused warnings like:

    cat: ./tools/testing/selftests/devices/probe/boards/Dell: No such file or directory
    cat: Inc.,XPS: No such file or directory

This patch replaces the loop with a more robust `find . -type f -print0 | while IFS= read -r -d ''` structure, which safely handles all valid filenames.

Signed-off-by: Sahil Kumar <kumar.sgoyal@gmail.com>