### PR TITLE
Fix: Missing return if F_DUPFD return TST_RET < min_fd

### DIFF
--- a/testcases/kernel/syscalls/fcntl/fcntl02.c
+++ b/testcases/kernel/syscalls/fcntl/fcntl02.c
@@ -36,10 +36,10 @@ static void verify_fcntl(unsigned int n)
 	if (TST_RET < min_fd) {
 		tst_res(TFAIL, "fcntl(%s, F_DUPFD, %i) returned %ld < %i",
 			fname, min_fd, TST_RET, min_fd);
+	} else {
+		tst_res(TPASS, "fcntl(%s, F_DUPFD, %i) returned %ld",
+			fname, min_fd, TST_RET);
 	}
-
-	tst_res(TPASS, "fcntl(%s, F_DUPFD, %i) returned %ld",
-		fname, min_fd, TST_RET);
 
 	SAFE_CLOSE(TST_RET);
 }


### PR DESCRIPTION
Fix: Missing return if F_DUPFD return TST_RET < min_fd

In fcntl02.c, if fcntl return TST_RET < min_fd, both tst_res(TFAIL) and tst_res(TPASS) will be running.

Signed-off-by: Binh Hoang <htb511@gmail.com>