### PR TITLE
Modify part of the name parameter in shm_open in ltp.

### DIFF
--- a/testcases/open_posix_testsuite/conformance/interfaces/mmap/1-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/mmap/1-2.c
@@ -29,7 +29,7 @@ int main(void)
 	size_t size = 1024 * 4 * 1024;
 	int fd;
 
-	snprintf(tmpfname, sizeof(tmpfname), "pts_mmap_1_2_%d", getpid());
+	snprintf(tmpfname, sizeof(tmpfname), "/pts_mmap_1_2_%d", getpid());
 
 	/* Create shared object */
 	shm_unlink(tmpfname);

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/1-1.c
@@ -28,7 +28,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_1-1"
+#define SHM_NAME "/posixtest_1-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/11-1.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_11-1"
+#define SHM_NAME "/posixtest_11-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/13-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/13-1.c
@@ -21,7 +21,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_13-1"
+#define SHM_NAME "/posixtest_13-1"
 #define BUF_SIZE 8
 
 int main(void)

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/14-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/14-2.c
@@ -28,7 +28,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_14-2"
+#define SHM_NAME "/posixtest_14-2"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/15-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/15-1.c
@@ -24,7 +24,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_15-1"
+#define SHM_NAME "/posixtest_15-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/16-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/16-1.c
@@ -22,7 +22,7 @@
 #include <unistd.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_16-1"
+#define SHM_NAME "/posixtest_16-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/17-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/17-1.c
@@ -22,7 +22,7 @@
 #include <unistd.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_17-1"
+#define SHM_NAME "/posixtest_17-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/18-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/18-1.c
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_18-1"
+#define SHM_NAME "/posixtest_18-1"
 
 /* execution bits is undefined */
 #define MOD_FLAGS     (S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH)	/* -w?rw?r-? */

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/20-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/20-1.c
@@ -22,7 +22,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_20-1"
+#define SHM_NAME "/posixtest_20-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/20-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/20-2.c
@@ -22,7 +22,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_20-2"
+#define SHM_NAME "/posixtest_20-2"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/20-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/20-3.c
@@ -22,7 +22,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_20-3"
+#define SHM_NAME "/posixtest_20-3"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/21-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/21-1.c
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_21-1"
+#define SHM_NAME "/posixtest_21-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/22-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/22-1.c
@@ -19,7 +19,7 @@
 #include <unistd.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_22-1"
+#define SHM_NAME "/posixtest_22-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/25-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/25-1.c
@@ -23,7 +23,7 @@
 #include <unistd.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_25-1"
+#define SHM_NAME "/posixtest_25-1"
 #define SHM_SZ 16
 
 int main(void)

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/26-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/26-1.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_26-1"
+#define SHM_NAME "/posixtest_26-1"
 #define CREATION_MODE S_IRUSR|S_IWUSR
 #define OPEN_MODE     S_IRGRP
 

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/26-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/26-2.c
@@ -33,7 +33,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_26-2"
+#define SHM_NAME "/posixtest_26-2"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/28-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/28-1.c
@@ -28,7 +28,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_28-1"
+#define SHM_NAME "/posixtest_28-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/28-2.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/28-2.c
@@ -28,7 +28,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_28-2"
+#define SHM_NAME "/posixtest_28-2"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/28-3.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/28-3.c
@@ -29,7 +29,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_28-3"
+#define SHM_NAME "/posixtest_28-3"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/32-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/32-1.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_32-1"
+#define SHM_NAME "/posixtest_32-1"
 
 /** Set the euid of this process to a non-root uid */
 static int set_nonroot()

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/34-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/34-1.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_34-1"
+#define SHM_NAME "/posixtest_34-1"
 
 /** Set the euid of this process to a non-root uid */
 static int set_nonroot()

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/38-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/38-1.c
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_38-1"
+#define SHM_NAME "/posixtest_38-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/41-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/41-1.c
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_41-1"
+#define SHM_NAME "/posixtest_41-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_open/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_open/8-1.c
@@ -30,7 +30,7 @@
 #include <fcntl.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_8-1"
+#define SHM_NAME "/posixtest_8-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/1-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/1-1.c
@@ -19,7 +19,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_1-1"
+#define SHM_NAME "/posixtest_1-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/11-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/11-1.c
@@ -16,7 +16,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_11-1"
+#define SHM_NAME "/posixtest_11-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/2-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/2-1.c
@@ -19,7 +19,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_2-1"
+#define SHM_NAME "/posixtest_2-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/3-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/3-1.c
@@ -21,7 +21,7 @@
 #include "posixtest.h"
 
 #define BUF_SIZE 8
-#define SHM_NAME "posixtest_3-1"
+#define SHM_NAME "/posixtest_3-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/5-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/5-1.c
@@ -19,7 +19,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_5-1"
+#define SHM_NAME "/posixtest_5-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/6-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/6-1.c
@@ -16,7 +16,7 @@
 #include <fcntl.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_6-1"
+#define SHM_NAME "/posixtest_6-1"
 
 int main(void)
 {

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/8-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/8-1.c
@@ -30,7 +30,7 @@
 #include <string.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_9-1"
+#define SHM_NAME "/posixtest_9-1"
 #define BUF_SIZE 8
 
 int main(void)

--- a/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/9-1.c
+++ b/testcases/open_posix_testsuite/conformance/interfaces/shm_unlink/9-1.c
@@ -30,7 +30,7 @@
 #include <string.h>
 #include "posixtest.h"
 
-#define SHM_NAME "posixtest_9-1"
+#define SHM_NAME "/posixtest_9-1"
 
 int main(void)
 {


### PR DESCRIPTION
The name parameter of shm_open needs to start with a forward slash:
 The  operation of shm_open() is analogous to that of open(2).  name specifies the shared memory object to be created or opened.  For porta‐ ble use, a shared memory object should be identified by a name of the form /somename; that is, a null-terminated string of up  to  NAME_MAX (i.e., 255) characters consisting of an initial slash, followed by one or more characters, none of which are slashes.
