### PR TITLE
syscalls: add RT group scheduling check to sched_setparam03/sched_football

### DIFF
--- a/testcases/kernel/syscalls/sched_setparam/sched_setparam03.c
+++ b/testcases/kernel/syscalls/sched_setparam/sched_setparam03.c
@@ -45,6 +45,7 @@ void setup(void)
 	struct sched_param p = { .sched_priority = 1 };
 
 	tst_res(TINFO, "Testing %s variant", tv->desc);
+	tst_check_rt_group_sched_support();
 
 	if (tv->sched_setscheduler(0, SCHED_FIFO, &p))
 		tst_brk(TBROK | TERRNO, "sched_setscheduler(0, SCHED_FIFO, 1)");

--- a/testcases/realtime/func/sched_football/sched_football.c
+++ b/testcases/realtime/func/sched_football/sched_football.c
@@ -206,6 +206,8 @@ static void do_setup(void)
 
 	if (tst_parse_int(str_players_per_team, &players_per_team, 1, INT_MAX))
 		tst_brk(TBROK, "Invalid number of players '%s'", str_players_per_team);
+
+	tst_check_rt_group_sched_support();
 }
 
 static struct tst_test test = {


### PR DESCRIPTION
The sched_setparam03/sched_football test case failed with a TBROK status when running on cgroupv2 environments where the process was restricted from setting the real-time policy (returning EPERM).

This commit adds a call to tst_check_rt_group_sched_support() which uses the configuration message TCONF: CONFIG_RT_GROUP_SCHED not support on cgroupv2.

The test now correctly skips instead of reporting a TBROK failure due to expected kernel configuration limitations.

BEFORE：
sched_setparam03.c:47: TINFO: Testing libc variant
sched_setparam03.c:50: TBROK: sched_setscheduler(0, SCHED_FIFO, 1): EPERM (1)

Summary:
passed   0
failed   0
broken   1
skipped  0
warnings 0

sched_football.c:162: TINFO: players_per_team: 8 game_length: 5
sched_football.c:178: TINFO: Starting 8 offense threads at priority 15
pthread_create failed: 1 (Operation not permitted)
pthread_create failed: 1 (Operation not permitted)
pthread_create failed: 1 (Operation not permitted)
pthread_create failed: 1 (Operation not permitted)
pthread_create failed: 1 (Operation not permitted)
pthread_create failed: 1 (Operation not permitted)
pthread_create failed: 1 (Operation not permitted)

NOW：
sched_setparam03.c:47: TINFO: Testing libc variant
tst_kconfig.c:88: TINFO: Parsing kernel config '/proc/config.gz'
tst_cgroup.c:1543: TCONF: CONFIG_RT_GROUP_SCHED not support on cgroupv2
sched_setparam03.c:47: TINFO: Testing syscall variant
tst_kconfig.c:88: TINFO: Parsing kernel config '/proc/config.gz'
tst_cgroup.c:1543: TCONF: CONFIG_RT_GROUP_SCHED not support on cgroupv2

Summary:
passed   0
failed   0
broken   0
skipped  2
warnings 0

sched_football.c:162: TINFO: players_per_team: 8 game_length: 5
tst_kconfig.c:88: TINFO: Parsing kernel config '/proc/config.gz'
tst_cgroup.c:1543: TCONF: CONFIG_RT_GROUP_SCHED not support on cgroupv2

Summary:
passed   0
failed   0
broken   0
skipped  1
warnings 0
