### PR TITLE
fanotify24: Fix ETXTBSY errno not set for pure FAN_PRE_ACCESS mask case

### DIFF
--- a/testcases/kernel/syscalls/fanotify/fanotify24.c
+++ b/testcases/kernel/syscalls/fanotify/fanotify24.c
@@ -264,7 +264,7 @@ static void generate_events(struct tcase *tc)
 	 */
 	if (!exp_errno) {
 		fd = SAFE_OPEN(FILE_EXEC_PATH, O_RDWR);
-		if (!tc->event_set[0].mask)
+		if (!tc->event_set[0].mask || (tc->mask == FAN_PRE_ACCESS))
 			exp_errno = ETXTBSY;
 	}
 


### PR DESCRIPTION
The fanotify24 test only set ETXTBSY errno for the no-monitor case, missed the pure FAN_PRE_ACCESS mask scenario. This caused execve() return errno 26 but expected 0 and test failure. Add pure FAN_PRE_ACCESS mask condition to the ETXTBSY check logic to cover this case.

[ type description here; PLEASE REMOVE THIS LINE AND THE LINES BELOW BEFORE SUBMITTING THIS PULL REQUEST ]

<!--
* Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/
There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).
LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.ozlabs.org/project/ltp/list/.

* Commits should be signed: Signed-off-by: Your Name <me@example.org>, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

* Commit message should be meaningful, following common style
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes
https://cbea.ms/git-commit/

* New code should follow Linux kernel coding style, see
https://www.kernel.org/doc/html/latest/process/coding-style.html.
You can run 'make check' or 'make check-foo' in the folder with modified code to check style and common errors.

* For more tips check
https://github.com/linux-test-project/ltp/wiki/Maintainer-Patch-Review-Checklist
https://github.com/linux-test-project/ltp/wiki/Test-Writing-Guidelines
https://github.com/linux-test-project/ltp/wiki/C-Test-API
https://github.com/linux-test-project/ltp/wiki/Shell-Test-API
https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial
-->
