### PR TITLE
syscalls/ustat: Skip tests on Btrfs using TCONF

### DIFF
--- a/testcases/kernel/syscalls/ustat/ustat01.c
+++ b/testcases/kernel/syscalls/ustat/ustat01.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/vfs.h>
 
 #include "lapi/syscalls.h"
 #include "lapi/ustat.h"
@@ -34,11 +35,16 @@ void run(void)
 static void setup(void)
 {
 	struct stat buf;
+	struct statfs fs_buf;
 
 	/* Find a valid device number */
 	SAFE_STAT("/", &buf);
-
 	dev_num = buf.st_dev;
+
+	statfs("/", &fs_buf);
+	if (fs_buf.f_type == 0x9123683E) {
+		tst_brk(TCONF, "%s", test.tags[0].value);
+	}
 }
 
 static struct tst_test test = {

--- a/testcases/kernel/syscalls/ustat/ustat02.c
+++ b/testcases/kernel/syscalls/ustat/ustat02.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/vfs.h>
 
 #include "lapi/syscalls.h"
 #include "lapi/ustat.h"
@@ -50,11 +51,16 @@ void run(unsigned int test)
 static void setup(void)
 {
 	struct stat buf;
+	struct statfs fs_buf;
 
 	/* Find a valid device number */
 	SAFE_STAT("/", &buf);
-
 	root_dev = buf.st_dev;
+
+	statfs("/", &fs_buf);
+	if (fs_buf.f_type == 0x9123683E) {
+		tst_brk(TCONF, "%s", test.tags[0].value);
+	}
 }
 
 static struct tst_test test = {


### PR DESCRIPTION
The ustat(2) system call is known to fail with EINVAL on Btrfs because it uses anonymous device IDs for subvolumes, which the legacy syscall cannot resolve to a physical block device.

Currently, this results in a TFAIL, which causes false negatives in automated CI environments (e.g., SLES). This patch adds dynamic filesystem detection in setup() and uses tst_brk(TCONF, ...) to gracefully skip the test on Btrfs.

Changes
- Added `sys/vfs.h` for `statfs` support.
- Implemented Btrfs magic number detection in `setup()`.
- Used `tst_brk(TCONF, ...)` to skip the test if Btrfs is detected.

Verified on:
- SLES (Btrfs): Result is now TCONF (Skipped)
- RHEL (XFS): Result remains TPASS