### PR TITLE
ched/starvation: handle explicit runtime and voluntary preempt

### DIFF
--- a/testcases/kernel/sched/cfs-scheduler/starvation.c
+++ b/testcases/kernel/sched/cfs-scheduler/starvation.c
@@ -105,10 +105,12 @@ static void setup(void)
 	if (tst_parse_long(str_loop, &loop, 1, LONG_MAX))
 		tst_brk(TBROK, "Invalid number of loop number '%s'", str_loop);
 
-	if (tst_parse_int(str_timeout, &timeout, 1, INT_MAX))
-		tst_brk(TBROK, "Invalid number of timeout '%s'", str_timeout);
-	else
+	if (str_timeout) {
+		if (tst_parse_int(str_timeout, &timeout, 1, INT_MAX))
+			tst_brk(TBROK, "Invalid number of timeout '%s'", str_timeout);
+	} else {
 		timeout = callibrate() / 1000;
+	}
 
 	if (tst_has_slow_kconfig())
 		tst_brk(TCONF, "Skip test due to slow kernel configuration");

--- a/testcases/kernel/sched/cfs-scheduler/starvation.c
+++ b/testcases/kernel/sched/cfs-scheduler/starvation.c
@@ -17,6 +17,7 @@
 #include <sys/wait.h>
 #include <stdlib.h>
 #include <sched.h>
+#include <string.h>
 
 #include "tst_test.h"
 #include "tst_kconfig.h"
@@ -29,6 +30,15 @@ static char *str_timeout;
 static int timeout;
 
 #define CALLIBRATE_LOOPS 120000000
+
+static int has_preempt_voluntary(void)
+{
+	struct tst_kconfig_var kconfig = TST_KCONFIG_INIT("CONFIG_PREEMPT_VOLUNTARY");
+
+	tst_kconfig_read(&kconfig, 1);
+
+	return kconfig.choice == 'y';
+}
 
 static int callibrate(void)
 {
@@ -80,6 +90,9 @@ static void setup(void)
 
 	if (tst_check_preempt_rt())
 		tst_brk(TCONF, "This test is not designed for the RT kernel");
+
+	if (has_preempt_voluntary())
+		tst_brk(TCONF, "This test is not reliable on voluntary preemption kernels");
 
 	CPU_ZERO(&mask);
 


### PR DESCRIPTION
  Fix two starvation runtime issues.

  The first patch makes the explicit `-t` option effective again. The
  current code parses the option, but then overwrites the value with the
  auto-calibrated runtime.

  The second patch skips the test on `CONFIG_PREEMPT_VOLUNTARY=y` kernels.
  On LoongArch 3C6000 with HZ=250 the same-CPU signal workload is limited
  by scheduler tick latency, not by signal delivery cost. `starvation -l
  10000` takes about 40 seconds and trace-cmd shows roughly 4ms between
  waking the parent and switching from the child to the parent. A minimal
  reproducer shows the same pattern: busy kill is about 4000us/loop, while
  kill plus sched_yield is about 5-9us/loop.

  Related mailing list background:
  - https://lore.kernel.org/ltp/20240722145443.19104-1-chrubis@suse.cz/
  - https://lore.kernel.org/ltp/20241222072251.13150-2-liwang@redhat.com/
  - https://lore.kernel.org/ltp/20250127083227.77560-1-acarmina@redhat.com/

  Validation:
  - `git diff --check HEAD~2..HEAD`
  - `make -C testcases/kernel/sched/cfs-scheduler starvation`
  - x86_64 Debian, PREEMPT_DYNAMIC: `starvation -l 1000 -t 10` passes and uses runtime 10s
  - LoongArch 3C6000, CONFIG_PREEMPT_VOLUNTARY=y: `starvation -l 100000 -t 240` returns TCONF instead of timing out

  `make check` was attempted, but the local environment could not fetch the
  required sparse/kirk/ltx/mce-test submodules due network restrictions.