### PR TITLE
Fix a repeat-run failure in setsockopt10

### DIFF
--- a/testcases/kernel/syscalls/setsockopt/setsockopt10.c
+++ b/testcases/kernel/syscalls/setsockopt/setsockopt10.c
@@ -77,8 +77,10 @@ static int tcp0_sk, tcp1_sk, tcp2_sk, tcp3_sk;
 
 static void setup(void)
 {
-	tst_init_sockaddr_inet(&tcp0_addr, "127.0.0.1", 0x7c90);
-	tst_init_sockaddr_inet(&tcp1_addr, "127.0.0.1", 0x7c91);
+	tst_init_sockaddr_inet(&tcp0_addr, "127.0.0.1",
+			       TST_GET_UNUSED_PORT(AF_INET, SOCK_STREAM));
+	tst_init_sockaddr_inet(&tcp1_addr, "127.0.0.1",
+			       TST_GET_UNUSED_PORT(AF_INET, SOCK_STREAM));
 }
 
 static void cleanup(void)


### PR DESCRIPTION
  Fix a repeat-run failure in setsockopt10.

  setsockopt10 is listed in both runtest/syscalls and runtest/cve, so a
  full run or `runltp -s setsockopt10` executes the same binary twice in
  quick succession. The test currently binds fixed localhost ports
  0x7c90/0x7c91, and the second execution can fail while the previous
  connection is still in TIME_WAIT:

      address is in use, waited  10 sec
      TBROK: tst_checkpoint_wait(0, 10000) failed: ETIMEDOUT

  Use `TST_GET_UNUSED_PORT()` for both test sockets to avoid depending on
  immediate reuse of fixed ports.

  Validation:
  - `git diff --check`
  - `make -C testcases/kernel/syscalls/setsockopt setsockopt10`
  - LoongArch/openEuler 6.6: `./runltp -s setsockopt10 -p -q` passes both matched entries