### PR TITLE
syscalls/cachestat03: Require CONFIG_COMPACTION=y

### DIFF
--- a/testcases/kernel/syscalls/cachestat/cachestat03.c
+++ b/testcases/kernel/syscalls/cachestat/cachestat03.c
@@ -74,4 +74,8 @@ static struct tst_test test = {
 		{&cs_range, .size = sizeof(struct cachestat_range)},
 		{}
 	},
+	.needs_kconfigs = (const char *[]) {
+		"CONFIG_COMPACTION=y",
+		NULL
+	}
 };


### PR DESCRIPTION
The test fails with TBROK on systems where CONFIG_COMPACTION is not enabled:
tst_hugepage.c:50: TBROK: Failed to open FILE '/proc/sys/vm/compact_memory' for writing: ENOENT (2) Summary:
passed   0
failed   0
broken   1

Fix this by adding CONFIG_COMPACTION=y to .needs_kconfigs, so that the test is skipped with TCONF on kernels without compaction support.
