### PR TITLE
include: Add noinline attribute helper

### DIFF
--- a/include/tst_common.h
+++ b/include/tst_common.h
@@ -9,6 +9,7 @@
 #ifndef TST_COMMON_H__
 #define TST_COMMON_H__
 
+#define LTP_ATTRIBUTE_NOINLINE		__attribute__((noinline))
 #define LTP_ATTRIBUTE_NORETURN		__attribute__((noreturn))
 #define LTP_ATTRIBUTE_UNUSED		__attribute__((unused))
 #define LTP_ATTRIBUTE_UNUSED_RESULT	__attribute__((warn_unused_result))

--- a/testcases/cve/meltdown.c
+++ b/testcases/cve/meltdown.c
@@ -45,7 +45,7 @@ clflush_target(void)
 extern char failshere[];
 extern char stopspeculate[];
 
-static void __attribute__((noinline))
+static void LTP_ATTRIBUTE_NOINLINE
 speculate(unsigned long addr, char bit)
 {
 	register char mybit asm ("cl") = bit;

--- a/testcases/cve/stack_clash.c
+++ b/testcases/cve/stack_clash.c
@@ -179,7 +179,7 @@ void dump_proc_self_maps(void)
 	tst_cmd(cmd, NULL, NULL, 0);
 }
 
-void __attribute__((noinline)) preallocate_stack(unsigned long required)
+void LTP_ATTRIBUTE_NOINLINE preallocate_stack(unsigned long required)
 {
 	volatile char *garbage;
 

--- a/testcases/kernel/syscalls/mmap/mmap18.c
+++ b/testcases/kernel/syscalls/mmap/mmap18.c
@@ -54,7 +54,7 @@
 
 static long page_size;
 
-static bool __attribute__((noinline)) check_stackgrow_up(void)
+static bool LTP_ATTRIBUTE_NOINLINE check_stackgrow_up(void)
 {
 	char local_var;
 	static char *addr;
@@ -104,7 +104,7 @@ static void *allocate_stack(size_t stack_size, size_t mapped_size)
 	return stack_bottom;
 }
 
-static __attribute__((noinline)) void *check_depth_recursive(void *limit)
+static LTP_ATTRIBUTE_NOINLINE void *check_depth_recursive(void *limit)
 {
 	if ((off_t) &limit < (off_t) limit) {
 		tst_res(TINFO, "&limit = %p, limit = %p", &limit, limit);

--- a/testcases/kernel/syscalls/pkeys/pkey01.c
+++ b/testcases/kernel/syscalls/pkeys/pkey01.c
@@ -141,7 +141,7 @@ static char *flag_to_str(int flags)
 	}
 }
 
-static long __attribute__ ((noinline)) dummy_func(void)
+static long LTP_ATTRIBUTE_NOINLINE dummy_func(void)
 {
 	return 0xdead;
 }

--- a/testcases/kernel/syscalls/profil/profil01.c
+++ b/testcases/kernel/syscalls/profil/profil01.c
@@ -52,7 +52,7 @@ static void alrm_handler(int sig)
 	profil_done = 1;
 }
 
-static void __attribute__ ((noinline)) *get_pc(void)
+static void LTP_ATTRIBUTE_NOINLINE *get_pc(void)
 {
 #if defined(__s390__) && defined(TST_ABI32)
 	/* taken from glibc,


### PR DESCRIPTION
## Summary

- add LTP_ATTRIBUTE_NOINLINE alongside the existing common compiler attribute helpers
- replace all current raw noinline compiler attribute uses in LTP tests
- keep compiler-specific syntax centralized and avoid checkpatch warnings at call sites

## Verification

- configured LTP in an isolated Debian 13 container
- built profil01, pkey01, mmap18, stack_clash, and meltdown
- ran the repository checkpatch configuration against the patch
- ran git diff --check

Closes #1318
