### PR TITLE
crypto_user02.c: try non-generic hmac names first

### DIFF
--- a/testcases/kernel/crypto/crypto_user02.c
+++ b/testcases/kernel/crypto/crypto_user02.c
@@ -35,6 +35,20 @@
  * The first algorithm, that fullfils the criteria is used for the test.
  */
 static const char * const ALGORITHM_CANDIDATES[] = {
+	"hmac(sha1)",
+	"hmac(sha224)",
+	"hmac(sha256)",
+	"hmac(sha384)",
+	"hmac(md5)",
+	"hmac(sm3)",
+	"hmac(sha512)",
+	"hmac(rmd160)",
+	"hmac(sha3-224)",
+	"hmac(sha3-256)",
+	"hmac(sha3-384)",
+	"hmac(sha3-512)",
+	"hmac(streebog256)",
+	"hmac(streebog512)",
 	"hmac(sha1-generic)",
 	"hmac(sha224-generic)",
 	"hmac(sha256-generic)",


### PR DESCRIPTION
Probe plain hmac(<hash>) driver names before the legacy *-generic variants when selecting a viable algorithm for crypto_user02.

Newer kernels commonly expose non-generic algorithm names while no longer registering the *-generic aliases, which made the current candidate list fall through to TCONF even when usable algorithms were present.

Keeping both forms preserves compatibility with older kernels while avoiding kernel-version checks in the testcase logic.
