### PR TITLE
inode01: Configure 4KB cluster size on exfat to prevent ENOSPC

### DIFF
--- a/testcases/kernel/fs/inode/inode01.c
+++ b/testcases/kernel/fs/inode/inode01.c
@@ -255,6 +255,10 @@ static struct tst_test test = {
 	.mntpoint = MNTPOINT,
 	.mount_device = 1,
 	.all_filesystems = 1,
+	.filesystems = (struct tst_fs[]) {
+		{.type = "exfat", .mkfs_opts = (const char *const[]) {"-c", "4K", NULL}},
+		{}
+	},
 	.needs_root = 1,
 	.dev_min_size = 512,
 	.forks_child = 1,


### PR DESCRIPTION
In the multi-process scenario, inode01 creates 10,920 objects (files and directories) across 5 parallel workers.

On Android, mkfs.exfat (exfatprogs) defaults to a 128KB cluster size on volumes <= 32GB. On a 512MB test volume, this provides only 4,080 clusters, causing the test to run out of clusters and fail with ENOSPC.

Fix this by configuring exfat to format with a 4KB cluster size (-c 4K) via the struct tst_fs mkfs_opts field.

<!--
* Although we *occasionally* also accept GitHub pull requests, the *preferred* way is sending patches to our mailing list: https://lore.kernel.org/ltp/
There is an example how to use it: https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial#7-submitting-the-test-for-review (using git format-patch and git send-email).
LTP mailing list is archived at: https://lore.kernel.org/ltp/.
We also have a patchwork instance: https://patchwork.kernel.org/project/ltp/list/.

* Commits should be signed: Signed-off-by: Your Name <me@example.org>, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

* Also other git tags might be relevant, see
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes

* Commit message should be meaningful, following common style
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#split-changes
https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes
https://cbea.ms/git-commit/

* New code should follow Linux kernel coding style, see
https://www.kernel.org/doc/html/latest/process/coding-style.html.
You can run 'make check' or 'make check-foo' in the folder with modified code to check style and common errors.

* For more tips check
https://github.com/linux-test-project/ltp/wiki/Maintainer-Patch-Review-Checklist
https://github.com/linux-test-project/ltp/wiki/Test-Writing-Guidelines
https://github.com/linux-test-project/ltp/wiki/C-Test-API
https://github.com/linux-test-project/ltp/wiki/Shell-Test-API
https://github.com/linux-test-project/ltp/wiki/C-Test-Case-Tutorial
-->
